### PR TITLE
Rebrand AOS to ACS across all documentation and files

### DIFF
--- a/.github/workflows/sync_version.py
+++ b/.github/workflows/sync_version.py
@@ -42,13 +42,13 @@ def main():
         f.write(updated_content)
     print(f"✓ Updated specification.md to version {version}")
     
-    # Update aos_schema.json
-    with open('specification/AOS/aos_schema.json', 'r') as f:
+    # Update acs_schema.json
+    with open('specification/ACS/acs_schema.json', 'r') as f:
         data = json.load(f)
     data['version'] = version
-    with open('specification/AOS/aos_schema.json', 'w') as f:
+    with open('specification/ACS/acs_schema.json', 'w') as f:
         json.dump(data, f, indent=4)
-    print(f"✓ Updated aos_schema.json to version {version}")
+    print(f"✓ Updated acs_schema.json to version {version}")
 
 
 if __name__ == "__main__":

--- a/.github/workflows/sync_version.yml
+++ b/.github/workflows/sync_version.yml
@@ -70,7 +70,7 @@ jobs:
             Updated files:
             - `pyproject.toml`
             - `docs/spec/instrument/specification.md`
-            - `specification/AOS/aos_schema.json`
+            - `specification/ACS/acs_schema.json`
             
             The version was read from the `version.txt` file.
           branch: version-sync-${{ env.VERSION }}
@@ -78,5 +78,5 @@ jobs:
           add-paths: |
             pyproject.toml
             docs/spec/instrument/specification.md
-            specification/AOS/aos_schema.json
+            specification/ACS/acs_schema.json
           

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Before finalizing any text, review against the Editorial Checklist in STYLE.md.
 
 ## Project Overview
 
-AOS (Agent Observability Standard) is the industry standard for building secure, observable AI agents. It delivers three core capabilities:
+ACS (Agent Control Standard) is the industry standard for building secure, observable AI agents. It delivers three core capabilities:
 - **Inspectability**: Complete visibility into agent components and capabilities
 - **Traceability**: Full trace trail with reasoning chains
 - **Instrumentability**: Hard controls and policy enforcement
@@ -35,7 +35,7 @@ uv pip install -e .
 ## Architecture Overview
 
 ### Core Framework Components
-The AOS framework consists of three interconnected layers:
+The ACS framework consists of three interconnected layers:
 
 1. **Instrument Layer** (Hooks)
    - Real-time control points that allow Guardian Agents to permit, deny, or modify agent actions
@@ -56,8 +56,8 @@ The AOS framework consists of three interconnected layers:
    - Critical for supply chain security and compliance
 
 ### Key Protocol Concepts
-- **Observed Agent**: The AI agent being monitored (implements AOS endpoints)
-- **Guardian Agent**: Enforces security policies and observability (consumes AOS data)
+- **Observed Agent**: The AI agent being monitored (implements ACS endpoints)
+- **Guardian Agent**: Enforces security policies and observability (consumes ACS data)
 - **Session**: Scoped interaction unit from activation to completion
 - **Step**: Atomic action/decision within agent reasoning process
 - **Hook Response**: Guardian's permit/deny/modify decision with optional mutations
@@ -72,12 +72,12 @@ The AOS framework consists of three interconnected layers:
 - **Standards Integration**: OpenTelemetry spans, OCSF events, SBOM formats
 
 ### Important Files
-- `specification/AOS/aos_schema.json`: Complete JSON Schema for AOS protocol
+- `specification/ACS/acs_schema.json`: Complete JSON Schema for ACS protocol
 - `docs/spec/instrument/specification.md`: Detailed protocol specification
 - `docs/spec/instrument/hooks.md`: Available hooks and their triggers
 - `docs/spec/trace/events.md`: Event catalog and schemas
 - `docs/topics/core_concepts.md`: Fundamental concepts and terminology
-- `docs/topics/AOS_in_action_example.md`: Step-by-step implementation example
+- `docs/topics/ACS_in_action_example.md`: Step-by-step implementation example
 - `mkdocs.yml`: Documentation site configuration
 
 ### Navigation Structure
@@ -90,7 +90,7 @@ The documentation follows this hierarchy:
 This is a documentation-focused project built with:
 - **UV** for Python dependency management (replaces pip)
 - **MkDocs Material** for documentation generation
-- **GitHub Pages** for hosting at aos.owasp.org
+- **GitHub Pages** for hosting at agentcontrolstandard.org
 
 ### Roadmap Context
 - **v0.1** (Current): Documentation, schemas, and requirements

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [aos@zenity.io](mailto:aos@zenity.io). All
+reported by contacting the project team at [acs@zenity.io](mailto:acs@zenity.io). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to AOS
+# Contributing to ACS
 
 We're building trustworthy AI agents together. Your contributions make the future of agent observability possible.
 
@@ -8,7 +8,7 @@ Search existing issues and pull requests to avoid duplicating efforts.
 
 ## How to Contribute
 
-**Ideas**: Join issue discussions or start new ones. Your voice shapes AOS direction.
+**Ideas**: Join issue discussions or start new ones. Your voice shapes ACS direction.
 
 **Writing**: Expand documentation with your expertise. Clear explanations help everyone.
 
@@ -16,7 +16,7 @@ Search existing issues and pull requests to avoid duplicating efforts.
 
 **Code**: Implement specifications, build tools, create examples.
 
-**Standards**: Help Improve AOS, extend CycloneDX, SPDX, SWID for agent components.
+**Standards**: Help Improve ACS, extend CycloneDX, SPDX, SWID for agent components.
 
 ## Development Process
 
@@ -39,7 +39,7 @@ All submissions require review via GitHub pull requests. Consult [GitHub Help](h
 ## What We Need
 
 **High Priority:**
-Look for unassigned [Open Issues](https://github.com/OWASP/www-project-agent-observability-standard/issues).
+Look for unassigned [Open Issues](https://github.com/Agent-Control-Standard/ACS/issues).
 
 **Always Welcome:**
 - Documentation improvements
@@ -76,7 +76,7 @@ This guide is based on [github-contributing](https://raw.githubusercontent.com/s
 
 ## Community
 
-- **[GitHub Discussions](https://github.com/OWASP/www-project-agent-observability-standard/discussions)**: Ask questions, share ideas
-- **[Issues](https://github.com/OWASP/www-project-agent-observability-standard/issues)**: Report bugs, request features
+- **[GitHub Discussions](https://github.com/Agent-Control-Standard/ACS/discussions)**: Ask questions, share ideas
+- **[Issues](https://github.com/Agent-Control-Standard/ACS/issues)**: Report bugs, request features
 
 We're building the future of AI agent observability. Join us.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Agent Observability Standard
+# Agent Control Standard
 
 [![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE.txt)
 
-![AOS Banner](docs/assets/banner.png)
+![ACS Banner](docs/assets/banner.png)
 
 **Making AI agents trustworthy by standardizing observability.**
 
@@ -20,43 +20,43 @@ For agents to become trustworthy they must be **inspectable, traceable and instr
 ### Key Components
 
 The standard covers the following aspects
-1. AOS that defines the interaction between the Observed Agent and the Guardian Agent
-2. Observability requirements and implementations for tracing all AOS events using OpenTelemetry and OCSF
+1. ACS that defines the interaction between the Observed Agent and the Guardian Agent
+2. Observability requirements and implementations for tracing all ACS events using OpenTelemetry and OCSF
 3. Agent BOM (AgBOM) requirements and implementations for exposing dynamic Agent's bill-of-material via CoycloneDX, SWID and SPDX
 
 ## Getting Started
 
-- 📚 **Explore the Documentation:** Visit the [Documentation Site](https://aos.owasp.org) for a complete overview, the full specification, tutorials, and guides.
-- 📝 **View the Specification:** [Specification](https://github.com/OWASP/www-project-agent-observability-standard/tree/main/specification)
+- 📚 **Explore the Documentation:** Visit the [Documentation Site](https://agentcontrolstandard.org) for a complete overview, the full specification, tutorials, and guides.
+- 📝 **View the Specification:** [Specification](https://github.com/Agent-Control-Standard/ACS/tree/main/specification)
 
 ## Contributing
 
-We welcome community contributions to enhance and evolve AOS!
+We welcome community contributions to enhance and evolve ACS!
 
 - **Questions & Discussions:** Join our [GitHub Discussions](do we have github enterprise?).
-- **Issues & Feedback:** Report issues or suggest improvements via [GitHub Issues](https://github.com/OWASP/www-project-agent-observability-standard/issues).
+- **Issues & Feedback:** Report issues or suggest improvements via [GitHub Issues](https://github.com/Agent-Control-Standard/ACS/issues).
 - **Contribution Guide:** See our [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute.
 
 ## What's next
 
 #### v0.1 (Public Preview)
 - Overall documentation and requirements
-- AOS definitions and schema
+- ACS definitions and schema
 - Observability definitions for for OpenTelemetry and OCSF
 - AgBOM requirements
 
 #### v1
 - Implementation of Agent instrumentation
 - Implementation of Guardian Agent sample app with
-  - AOS Support
-  - AOS to OpenTelemetry mapper
-  - AOS to OCSF mapper
-- FastMCP client instrumentation for AOS
-- A2A client instrumentation for AOS
+  - ACS Support
+  - ACS to OpenTelemetry mapper
+  - ACS to OCSF mapper
+- FastMCP client instrumentation for ACS
+- A2A client instrumentation for ACS
 
 #### v2
 - Requirements for CycloneDX, SPDX, SWID
-- Implementation of AOS to AgBOM mappers for CycloneDX, SPDX, SWID
+- Implementation of ACS to AgBOM mappers for CycloneDX, SPDX, SWID
 
 #### v3
 - Extending A2A and MCP to support deny and modify operations
@@ -64,4 +64,4 @@ We welcome community contributions to enhance and evolve AOS!
 
 ## About
 
-The AOS is an open-source project under the [MIT License](LICENSE.txt), and is open to contributions from the community.
+The ACS is an open-source project under the [MIT License](LICENSE.txt), and is open to contributions from the community.

--- a/STYLE.md
+++ b/STYLE.md
@@ -1,4 +1,4 @@
-# AOS Editorial Style Guide
+# ACS Editorial Style Guide
 
 ## Core Philosophy
 
@@ -20,7 +20,7 @@
 
 ### Language Choices
 - Active voice dominates: "Agents expose events" not "Events are exposed by agents"
-- Present tense when possible: "AOS provides" not "AOS will provide"
+- Present tense when possible: "ACS provides" not "ACS will provide"
 - Technical terms get defined once, then used freely
 
 ## Structure Guidelines

--- a/docs/README.md
+++ b/docs/README.md
@@ -53,5 +53,5 @@ Early standardization provides a unique opportunity to build trustworthiness int
 
 ## Read Next
 
-- [AOS](./aos.md)
+- [ACS](./acs.md)
 - [Core Concepts](./topics/core_concepts.md)

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,16 +1,16 @@
-# About AOS
+# About ACS
 
-Agent Observability Standard (AOS) creates industry-wide transparency for AI agents.
+Agent Control Standard (ACS) creates industry-wide transparency for AI agents.
 
 ## Mission
 
 Transform AI agents from black boxes into trustworthy systems through standardized observability.
 
-Enterprises need to see what agents do, understand why they act, and control their behavior. AOS provides the specifications and protocols to make this possible.
+Enterprises need to see what agents do, understand why they act, and control their behavior. ACS provides the specifications and protocols to make this possible.
 
 ## What We're Building
 
-**Instrumentation Standard**: AOS standard for agent instrumentation.
+**Instrumentation Standard**: ACS standard for agent instrumentation.
 
 **Standards Extensions**: Enhance CycloneDX, SPDX, SWID for AI agent components. Extend OCSF and OpenTelemetry with agent-specific schemas.
 
@@ -22,10 +22,10 @@ Enterprises need to see what agents do, understand why they act, and control the
 
 ## Join the Mission
 
-AOS succeeds when the entire AI agent ecosystem adopts these standards. We're building this together.
+ACS succeeds when the entire AI agent ecosystem adopts these standards. We're building this together.
 
 - **Contribute**: Help shape the specifications
-- **Implement**: Build AOS support in your agent platform
+- **Implement**: Build ACS support in your agent platform
 - **Advocate**: Spread the word about trustworthy agents
 
-Contact us at [aos@zenity.io](mailto:aos@zenity.io).
+Contact us at [acs@zenity.io](mailto:acs@zenity.io).

--- a/docs/acs.md
+++ b/docs/acs.md
@@ -1,7 +1,7 @@
-# Agent Observability Standard
+# Agent Control Standard
 
-The Agent Observability Standard (AOS) provides specification for building [trustworthy agents](./README.md).
-Agents that implement AOS can be deployed with higher trust.
+The Agent Control Standard (ACS) provides specification for building [trustworthy agents](./README.md).
+Agents that implement ACS can be deployed with higher trust.
 They are instrumentable, traceable and inspectable.
 They are an open book 
 
@@ -12,23 +12,23 @@ They have a dynamic bill-of-material, a clear audit trail and hard inline-contro
 Trustworthiness of agents builds upon the foundation of existing standards (MCP and A2A), but provides value regardless. 
 It build upon cybersecurity and observability standards including OpenTelemetry, OCSF, CycloneDX, SPDX and SWID.
 
-AOS makes agents trustworthy.
+ACS makes agents trustworthy.
 
 !!! info "Work in progress"
     This page is currently under development.
     
-    **Want to contribute?** Check out the [GitHub issue](https://github.com/OWASP/www-project-agent-observability-standard/issues/53) and join the discussion!
+    **Want to contribute?** Check out the [GitHub issue](https://github.com/Agent-Control-Standard/ACS/issues/53) and join the discussion!
 
 ## Trustworthy agents are
 
-??? example "Init agent with AOS"
+??? example "Init agent with ACS"
 
     === "LangChain (Python)"
 
         ```python
         from langchain.agents import initialize_agent, Tool
         from langchain.llms import OpenAI
-        from aos import AOSInstrument
+        from acs import ACSInstrument
         
         # Initialize LLM and tools
         llm = OpenAI(temperature=0)
@@ -45,7 +45,7 @@ AOS makes agents trustworthy.
             )
         ]
         
-        # Create agent with AOS instrumentation
+        # Create agent with ACS instrumentation
         agent = initialize_agent(
             tools, 
             llm, 
@@ -53,15 +53,15 @@ AOS makes agents trustworthy.
             verbose=True
         )
         
-        # Wrap with AOS for observability
-        aos_agent = AOSInstrument(agent)
+        # Wrap with ACS for observability
+        acs_agent = ACSInstrument(agent)
         ```
 
     === "Vercel AI SDK (TypeScript)"
 
         ```typescript
         import { createAgent } from '@vercel/ai'
-        import { AOSInstrument } from '@aos/sdk'
+        import { ACSInstrument } from '@acs/sdk'
         
         // Define tools
         const tools = {
@@ -81,14 +81,14 @@ AOS makes agents trustworthy.
           }
         }
         
-        // Create agent with AOS instrumentation
+        // Create agent with ACS instrumentation
         const agent = createAgent({
           model: 'gpt-4',
           tools,
           system: 'You are a helpful assistant'
         })
         
-        const aosAgent = new AOSInstrument(agent)
+        const acsAgent = new ACSInstrument(agent)
         ```
 
     === "MCP"
@@ -102,9 +102,9 @@ AOS makes agents trustworthy.
             "capabilities": {
               "tools": ["search", "calculate"],
               "models": ["claude-3-opus"],
-              "protocols": ["mcp", "aos"]
+              "protocols": ["mcp", "acs"]
             },
-            "aos": {
+            "acs": {
               "instrumentation": {
                 "enabled": true,
                 "hooks": ["agentTrigger", "toolCallRequest", "message"]
@@ -121,7 +121,7 @@ AOS makes agents trustworthy.
     === "A2A"
 
         ```yaml
-        # Agent manifest with AOS capabilities
+        # Agent manifest with ACS capabilities
         apiVersion: a2a.io/v1
         kind: Agent
         metadata:
@@ -135,7 +135,7 @@ AOS makes agents trustworthy.
             - search
             - calculate
           observability:
-            aos:
+            acs:
               version: "1.0"
               instrumentation:
                 hooks:
@@ -158,12 +158,12 @@ AOS makes agents trustworthy.
 
     **Description**: Specifies hooks that allow intervention at agent's lifecycle and run-time execution.
 
-    **Standards**: [AOS Instrument](./spec/instrument/README.md).
+    **Standards**: [ACS Instrument](./spec/instrument/README.md).
 
     === "LangChain (Python)"
 
         ```python
-        from aos import GuardianAgent, PolicyResponse
+        from acs import GuardianAgent, PolicyResponse
         
         # Create a Guardian Agent to enforce policies
         guardian = GuardianAgent(
@@ -172,7 +172,7 @@ AOS makes agents trustworthy.
         )
         
         # Hook into agent runtime
-        @aos_agent.hook("toolCallRequest")
+        @acs_agent.hook("toolCallRequest")
         async def on_tool_call(context):
             # Guardian evaluates the tool call
             response = await guardian.evaluate({
@@ -191,14 +191,14 @@ AOS makes agents trustworthy.
             return response
         
         # Example: Guardian denies sensitive data access
-        result = await aos_agent.run("Search for employee SSN records")
+        result = await acs_agent.run("Search for employee SSN records")
             # > PermissionError: Tool call denied: Accessing PII data violates policy
         ```
 
     === "Vercel AI (TypeScript)"
 
         ```typescript
-        import { GuardianAgent, HookContext } from '@aos/guardian'
+        import { GuardianAgent, HookContext } from '@acs/guardian'
         
         // Configure Guardian Agent
         const guardian = new GuardianAgent({
@@ -207,7 +207,7 @@ AOS makes agents trustworthy.
         })
         
         // Register hooks for runtime control
-        aosAgent.registerHook('toolCallRequest', async (context: HookContext) => {
+        acsAgent.registerHook('toolCallRequest', async (context: HookContext) => {
           const response = await guardian.evaluate({
             hook: 'toolCallRequest',
             tool: context.toolName,
@@ -227,7 +227,7 @@ AOS makes agents trustworthy.
         })
         
         // Example: Cost control policy in action
-        await aosAgent.run('Generate 1000 images using DALL-E')
+        await acsAgent.run('Generate 1000 images using DALL-E')
         // > Error: Denied: Request exceeds cost threshold ($50 limit)
         ```
 
@@ -236,7 +236,7 @@ AOS makes agents trustworthy.
         ```json
         {
           "jsonrpc": "2.0",
-          "method": "aos/registerHook",
+          "method": "acs/registerHook",
           "params": {
             "hook": "toolCallRequest",
             "guardianEndpoint": "https://guardian.example.com/evaluate",
@@ -276,7 +276,7 @@ AOS makes agents trustworthy.
     === "A2A"
 
         ```yaml
-        # Available AOS hooks for instrumentation
+        # Available ACS hooks for instrumentation
         
         agentTrigger:
           description: Fires when agent starts processing
@@ -312,26 +312,26 @@ AOS makes agents trustworthy.
 
     **Description**: Specifies events that capture AI agent lifecycle and runtime execution. Extends OpenTelemetry and OCSF specs with these properties.
 
-    **Standards**: [AOS Trace](./spec/trace/README.md). Extends [OpenTelemetry](./spec/trace/extend_opentelemetry.md), [OCSF](./spec/trace/extend_ocsf.md).
+    **Standards**: [ACS Trace](./spec/trace/README.md). Extends [OpenTelemetry](./spec/trace/extend_opentelemetry.md), [OCSF](./spec/trace/extend_ocsf.md).
 
     === "LangChain (Python)"
 
         ```python
         from opentelemetry import trace
-        from aos.trace import AOSTraceProvider
+        from acs.trace import ACSTraceProvider
         
-        # Configure OpenTelemetry with AOS extensions
+        # Configure OpenTelemetry with ACS extensions
         tracer = trace.get_tracer(
             "research-assistant",
-            provider=AOSTraceProvider()
+            provider=ACSTraceProvider()
         )
         
         # Agent execution with automatic tracing
         with tracer.start_as_current_span("agent_session") as span:
-            span.set_attribute("aos.session.id", "sess_123")
-            span.set_attribute("aos.agent.name", "research-assistant")
+            span.set_attribute("acs.session.id", "sess_123")
+            span.set_attribute("acs.agent.name", "research-assistant")
             
-            result = await aos_agent.run("Find recent AI safety papers")
+            result = await acs_agent.run("Find recent AI safety papers")
         
         # Trace output includes:
         # - Complete reasoning chain
@@ -347,14 +347,14 @@ AOS makes agents trustworthy.
           "operationName": "agent_session",
           "startTime": "2024-01-15T10:30:00Z",
           "attributes": {
-            "aos.session.id": "sess_123",
-            "aos.agent.name": "research-assistant",
-            "aos.reasoning.steps": 3,
-            "aos.tools.called": ["web-search", "summarize"]
+            "acs.session.id": "sess_123",
+            "acs.agent.name": "research-assistant",
+            "acs.reasoning.steps": 3,
+            "acs.tools.called": ["web-search", "summarize"]
           },
           "events": [
             {
-              "name": "aos.step.reasoning",
+              "name": "acs.step.reasoning",
               "timestamp": "2024-01-15T10:30:01Z",
               "attributes": {
                 "thought": "Need to search for recent AI safety papers",
@@ -369,7 +369,7 @@ AOS makes agents trustworthy.
     === "Vercel AI (TypeScript)"
 
         ```typescript
-        import { OpenTelemetryTracer } from '@aos/trace'
+        import { OpenTelemetryTracer } from '@acs/trace'
         
         // Configure tracing for TypeScript agent
         const tracer = new OpenTelemetryTracer({
@@ -378,7 +378,7 @@ AOS makes agents trustworthy.
         })
         
         // Wrap agent with tracing
-        const tracedAgent = tracer.instrument(aosAgent)
+        const tracedAgent = tracer.instrument(acsAgent)
         
         // Execute with automatic tracing
         const result = await tracedAgent.run('Find recent AI safety papers')
@@ -391,7 +391,7 @@ AOS makes agents trustworthy.
         ```json
         {
           "jsonrpc": "2.0",
-          "method": "aos/trace/emit",
+          "method": "acs/trace/emit",
           "params": {
             "traceId": "4bf92f3577b34da6a3ce929d0e0e4736",
             "spanId": "00f067aa0ba902b7",
@@ -437,7 +437,7 @@ AOS makes agents trustworthy.
     === "OCSF"
 
         ```python
-        from aos.trace import OCSFLogger
+        from acs.trace import OCSFLogger
         
         # Configure OCSF security event logging
         security_logger = OCSFLogger(
@@ -446,10 +446,10 @@ AOS makes agents trustworthy.
         )
         
         # Attach to agent for security events
-        aos_agent.attach_logger(security_logger)
+        acs_agent.attach_logger(security_logger)
         
         # Execute agent - security events logged automatically
-        result = await aos_agent.run("Access customer database")
+        result = await acs_agent.run("Access customer database")
         ```
         
         ```json
@@ -465,7 +465,7 @@ AOS makes agents trustworthy.
           "metadata": {
             "version": "1.0.0",
             "product": {
-              "name": "AOS Agent",
+              "name": "ACS Agent",
               "vendor_name": "Example Corp"
             }
           },
@@ -479,7 +479,7 @@ AOS makes agents trustworthy.
               "uid": "agent_456"
             }
           },
-          "aos_extensions": {
+          "acs_extensions": {
             "reasoning_chain": [
               {
                 "step": 1,
@@ -497,10 +497,10 @@ AOS makes agents trustworthy.
     === "Real-time Streaming"
 
         ```typescript
-        import { AOSTraceStream } from '@aos/trace'
+        import { ACSTraceStream } from '@acs/trace'
         
         // Stream trace events in real-time
-        const traceStream = new AOSTraceStream(aosAgent)
+        const traceStream = new ACSTraceStream(acsAgent)
         
         traceStream.on('event', (event) => {
           // Log to your observability platform
@@ -530,15 +530,15 @@ AOS makes agents trustworthy.
 
     **Description**: Specifies properties that capture tools, models and capabilities of an AI agent. Extends SBOM standard specs with these properties – AgBOM. Goes further to add dynamic updates to AgBOM to account for dynamic agent capability discovery.
 
-    **Standards**: [AOS Inspect](./spec/inspect/README.md). Extends [CycloneDX](./spec/inspect/extend_cyclonedx.md), [SPDX](./spec/inspect/extend_spdx.md), [SWID](./spec/inspect/extend_swid.md).
+    **Standards**: [ACS Inspect](./spec/inspect/README.md). Extends [CycloneDX](./spec/inspect/extend_cyclonedx.md), [SPDX](./spec/inspect/extend_spdx.md), [SWID](./spec/inspect/extend_swid.md).
 
     === "LangChain (Python)"
 
         ```python
-        from aos.inspect import generate_agbom
+        from acs.inspect import generate_agbom
         
         # Generate Agent Bill of Materials in CycloneDX format
-        agbom = generate_agbom(aos_agent, format="cyclonedx")
+        agbom = generate_agbom(acs_agent, format="cyclonedx")
         
         print(agbom.to_json(indent=2))
         ```
@@ -580,10 +580,10 @@ AOS makes agents trustworthy.
     === "Vercel AI (TypeScript)"
 
         ```typescript
-        import { generateAgBOM } from '@aos/inspect'
+        import { generateAgBOM } from '@acs/inspect'
         
         // Generate AgBOM in CycloneDX format for TypeScript agent
-        const agbom = await generateAgBOM(aosAgent, {
+        const agbom = await generateAgBOM(acsAgent, {
           format: 'cyclonedx'
         })
         
@@ -596,7 +596,7 @@ AOS makes agents trustworthy.
         ```json
         {
           "jsonrpc": "2.0",
-          "method": "aos/agbom/generate",
+          "method": "acs/agbom/generate",
           "params": {
             "format": "cyclonedx",
             "agent_id": "research-assistant"
@@ -667,10 +667,10 @@ AOS makes agents trustworthy.
     === "SPDX"
 
         ```python
-        from aos.inspect import generate_agbom
+        from acs.inspect import generate_agbom
         
         # Generate Agent Bill of Materials in SPDX format
-        agbom = generate_agbom(aos_agent, format="spdx")
+        agbom = generate_agbom(acs_agent, format="spdx")
         
         print(agbom.to_string())
         ```
@@ -681,7 +681,7 @@ AOS makes agents trustworthy.
         SPDXID: SPDXRef-DOCUMENT
         DocumentName: research-assistant-agbom
         DocumentNamespace: https://example.com/agbom/research-assistant
-        Creator: Tool: aos-sdk-1.0
+        Creator: Tool: acs-sdk-1.0
         Created: 2024-01-15T10:30:00Z
         
         # Package: AI Agent
@@ -709,11 +709,11 @@ AOS makes agents trustworthy.
     === "Dynamic Discovery"
 
         ```python
-        from aos.inspect import DynamicAgBOM
+        from acs.inspect import DynamicAgBOM
         import asyncio
         
         # Enable dynamic AgBOM updates
-        dynamic_agbom = DynamicAgBOM(aos_agent)
+        dynamic_agbom = DynamicAgBOM(acs_agent)
         
         # Subscribe to capability changes
         @dynamic_agbom.on_update
@@ -728,7 +728,7 @@ AOS makes agents trustworthy.
             await notify_security_team(new_agbom)
         
         # Example: Agent discovers new tool at runtime
-        await aos_agent.run("I need to analyze this PDF document")
+        await acs_agent.run("I need to analyze this PDF document")
         
         # Output:
         # Agent capability changed: COMPONENT_ADDED
@@ -740,10 +740,10 @@ AOS makes agents trustworthy.
     === "Real-time Updates"
 
         ```typescript
-        import { DynamicAgBOM, AgBOMEvent } from '@aos/inspect'
+        import { DynamicAgBOM, AgBOMEvent } from '@acs/inspect'
         
         // Create dynamic AgBOM monitor
-        const dynamicAgBOM = new DynamicAgBOM(aosAgent)
+        const dynamicAgBOM = new DynamicAgBOM(acsAgent)
         
         // Listen for capability changes
         dynamicAgBOM.on('update', async (event: AgBOMEvent) => {
@@ -757,7 +757,7 @@ AOS makes agents trustworthy.
           
           if (!validation.approved) {
             // Disable unapproved capability
-            await aosAgent.disableComponent(event.component.id)
+            await acsAgent.disableComponent(event.component.id)
             console.warn(`Disabled unapproved component: ${event.component.name}`)
           }
         })

--- a/docs/spec/inspect/README.md
+++ b/docs/spec/inspect/README.md
@@ -1,9 +1,9 @@
-# Agent Observability Standard - Inspect with AgBOM
+# Agent Control Standard - Inspect with AgBOM
 
 As AI agents become more sophisticated, transparent insight into their architecture, behavior, and security posture becomes critical. The Agent Bill of Materials (AgBOM) addresses this need by providing a structured, dynamic inventory of all components comprising an agent system including tools, models, capabilities, and dependencies. This concept aligns with growing calls for AI system transparency and supply chain integrity, particularly within regulated or enterprise environments.
 
 !!! info "AgBOM Extends Industry Standards"
-    We already have great Bill-of-Material standards, so AOS doesn't introduce a new one. Instead, it extends existing industry-proven standards: CycloneDX, SPDX, and SWID to support AI agent-specific components.
+    We already have great Bill-of-Material standards, so ACS doesn't introduce a new one. Instead, it extends existing industry-proven standards: CycloneDX, SPDX, and SWID to support AI agent-specific components.
 
 ## What Is AgBOM?
 AgBOM, short for Agent Bill-of-Materials, is a comprehensive inventory that captures metadata about every component in an AI agent system. Its core purpose is to enable inspectability, allowing developers, auditors, and stakeholders to determine:
@@ -21,8 +21,8 @@ To support industry-wide adoption and interoperability, AgBOM supports output in
 | BOM standard | AgBOM Spec | Status |
 |--|--|--|
 | [CycloneDX](https://cyclonedx.org/) | [AgBOM with CycloneDX](./extend_cyclonedx.md) | Working draft |
-| [SPDX](https://spdx.dev/) | [AgBOM with SPDX](./extend_spdx.md) | [Help wanted](https://github.com/OWASP/www-project-agent-observability-standard/issues/20) |
-| [SWID](https://csrc.nist.gov/Projects/Software-Identification-SWID) | [AgBOM with SWID](./extend_swid.md) | [Help wanted](https://github.com/OWASP/www-project-agent-observability-standard/issues/21) |
+| [SPDX](https://spdx.dev/) | [AgBOM with SPDX](./extend_spdx.md) | [Help wanted](https://github.com/Agent-Control-Standard/ACS/issues/20) |
+| [SWID](https://csrc.nist.gov/Projects/Software-Identification-SWID) | [AgBOM with SWID](./extend_swid.md) | [Help wanted](https://github.com/Agent-Control-Standard/ACS/issues/21) |
 
 ### AgBOM entities and parameters:
 

--- a/docs/spec/inspect/extend_cyclonedx.md
+++ b/docs/spec/inspect/extend_cyclonedx.md
@@ -3,7 +3,7 @@
 !!! info "Work in progress"
     This specification is currently under development. We're working on defining how AgBOM extends SPDX to support AI agent components.
     
-    **Want to contribute?** Check out the [GitHub issue](https://github.com/OWASP/www-project-agent-observability-standard/issues/22) and join the discussion!
+    **Want to contribute?** Check out the [GitHub issue](https://github.com/Agent-Control-Standard/ACS/issues/22) and join the discussion!
 
 Agent Bill of Material example using CycloneDX
 

--- a/docs/spec/inspect/extend_spdx.md
+++ b/docs/spec/inspect/extend_spdx.md
@@ -3,4 +3,4 @@
 !!! warning "Help wanted"
     This specification is currently under development. We're working on defining how AgBOM extends SPDX to support AI agent components.
     
-    **Want to contribute?** Check out the [GitHub issue](https://github.com/OWASP/www-project-agent-observability-standard/issues/20) and join the discussion!
+    **Want to contribute?** Check out the [GitHub issue](https://github.com/Agent-Control-Standard/ACS/issues/20) and join the discussion!

--- a/docs/spec/inspect/extend_swid.md
+++ b/docs/spec/inspect/extend_swid.md
@@ -3,4 +3,4 @@
 !!! warning "Help wanted"
     This specification is currently under development. We're working on defining how AgBOM extends SWID to support AI agent components.
     
-    **Want to contribute?** Check out the [GitHub issue](https://github.com/OWASP/www-project-agent-observability-standard/issues/21) and join the discussion!
+    **Want to contribute?** Check out the [GitHub issue](https://github.com/Agent-Control-Standard/ACS/issues/21) and join the discussion!

--- a/docs/spec/instrument/README.md
+++ b/docs/spec/instrument/README.md
@@ -1,10 +1,10 @@
-# Agent Observability Standard - Instrument
+# Agent Control Standard - Instrument
 
 AI agents make critical decisions autonomously. They collaborate, execute code, and access sensitive data. But they operate as black boxes. Enterprises can't trust what they can't see.
 
-AOS introduces a standard way to introduce middleware into agent systems to steer its behavior. It transforms opaque agents into transparent, controllable systems.
+ACS introduces a standard way to introduce middleware into agent systems to steer its behavior. It transforms opaque agents into transparent, controllable systems.
 
-## What AOS Instrumentation Delivers
+## What ACS Instrumentation Delivers
 
 **Real-time Control**: Guardian Agents intercept every agent action. Apply enterprise policies. Block data leaks. Enforce compliance before actions execute.
 
@@ -14,19 +14,19 @@ AOS introduces a standard way to introduce middleware into agent systems to stee
 
 ## How It Works
 
-AOS is a standard for surfacing every decision, action, prompt, and output as structured events while simultaneously providing hooks for in-line intervention and control.
+ACS is a standard for surfacing every decision, action, prompt, and output as structured events while simultaneously providing hooks for in-line intervention and control.
 It create a standard way to insert middleware into agent execution.
 Embedding lightweight call-outs at each step of an agent’s reasoning and action cycle.
-AOS streams context-rich events to observability back-ends, and allows guardian agents to allow, veto or modify behavior.
+ACS streams context-rich events to observability back-ends, and allows guardian agents to allow, veto or modify behavior.
 
-AOS works even better when MCP and A2A are used.
+ACS works even better when MCP and A2A are used.
 It carries these protocols intact, allowing transparent adoption while providing observability value.
 
-| Standard | AOS Spec | Status |
+| Standard | ACS Spec | Status |
 |--|--|--|
-| [MCP](https://modelcontextprotocol.io/introduction) | [AOS with MCP](./extend_mcp.md) | Working draft |
-| [A2A](https://google-a2a.github.io/A2A/) | [AOS with A2A](./a2a/extend_a2a.md) | Working draft |
+| [MCP](https://modelcontextprotocol.io/introduction) | [ACS with MCP](./extend_mcp.md) | Working draft |
+| [A2A](https://google-a2a.github.io/A2A/) | [ACS with A2A](./a2a/extend_a2a.md) | Working draft |
 
 ### Read Next
 
-- [AOS Instrumentation Specification](./specification.md)
+- [ACS Instrumentation Specification](./specification.md)

--- a/docs/spec/instrument/a2a/extend_a2a.md
+++ b/docs/spec/instrument/a2a/extend_a2a.md
@@ -4,33 +4,33 @@
 [A2A](https://developers.googleblog.com/en/a2a-a-new-era-of-agent-interoperability/) is a communication protocol that enables AI agents or autonomous systems to exchange information, coordinate actions, or delegate tasks in a structured and secure way.<br><br>
 It defines how two or more agents exchange messages, requests, responses or task results and enables AI agents, built on diverse frameworks by different companies running on separate servers, to communicate and collaborate effectively.<br><br>
 In the landscape where the world is leaning towards multi-agent systems, where these agents can be autonomous or semi-autonomous, working together to solve problems or perform tasks that would be difficult or impossible for a single agent or monolithic system, A2A protocol is essential for standardizing inter-agent communication—making it easier to build, compose, and scale these systems.<br><br>
-Securing A2A protocol with AOS extension is crucial for agent security and observability.
+Securing A2A protocol with ACS extension is crucial for agent security and observability.
 
 ## A2A support
 
-AOS extension for A2A is used as a **transport** for A2A communications between the agent and the guardian agent. Meaning AOS understands and delivers A2A message as is.<br>
+ACS extension for A2A is used as a **transport** for A2A communications between the agent and the guardian agent. Meaning ACS understands and delivers A2A message as is.<br>
 Securing A2A means securing outbound and inbound communications/messages.<br>
 Observed agent can be either [client agent](https://google-a2a.github.io/A2A/latest/specification/#12-guiding-principles) (agent that initiates A2A requests to the server agent), [server (remote) agent](https://google-a2a.github.io/A2A/latest/specification/#12-guiding-principles) (an agent that exposes an A2A-compliant HTTP endpoint, processing tasks and providing responses) or both.
 
 #### To extend A2A protocol:
-1. Agents using A2A ***must*** use AOS as a transport protocol to deliver A2A messages to the guardian agent.
-2. Agents using A2A ***must*** understand and enforce AOS responses. <br><br>
+1. Agents using A2A ***must*** use ACS as a transport protocol to deliver A2A messages to the guardian agent.
+2. Agents using A2A ***must*** understand and enforce ACS responses. <br><br>
 
 ![Extend A2A protocol](../../../assets/extend_a2a.png "Extend A2A protocol illustration")
 
 #### The following flow explains how this should be done:
 1. Client agent **A** prepares A2A-compliant message.
-2. Client agent **A** uses AOS as a transport to send the message to the guardian agent (hook #1 in the diagram).
+2. Client agent **A** uses ACS as a transport to send the message to the guardian agent (hook #1 in the diagram).
 3. The guardian agent understands and processes the A2A transported message and send the result back to client agent **A**.
 4. Client agent **A** interprets and enforces the response from guardian agent.
 5. In case response is `allow`, agent **A** sends the A2A message to server agent **B**.
-6. Server agent **B** uses AOS as a transport to send the recived message to the guardian agent (hook #2 in the diagram).
+6. Server agent **B** uses ACS as a transport to send the recived message to the guardian agent (hook #2 in the diagram).
 7. In case response is `allow`, agent **B** processes the message and prepares A2A-compliant response.
-8. Server agent **B** uses AOS as a transport to send the reponse to the guardian agent (hook #3 in the diagram).
+8. Server agent **B** uses ACS as a transport to send the reponse to the guardian agent (hook #3 in the diagram).
 9. The guardian agent understands and processes the A2A transported response and send the result back to the server agent **B**.
 10. Server agent **B** interprets and enforces the response from guardian agent.
 11. In case response is `allow`, agent **B** sends the A2A response to client agent **A**. 
-12. Client agent **A** uses AOS as a transport to send the A2A response to the guardian agent, using protocol's `method` field as the request `method` name.
+12. Client agent **A** uses ACS as a transport to send the A2A response to the guardian agent, using protocol's `method` field as the request `method` name.
 13. The guardian agent understands and processes the A2A transported response and send the result back to agent **A**.
 14. Client agent **A** interprets and enforces the response from guardian agent.
 
@@ -47,7 +47,7 @@ Observed agent can be either [client agent](https://google-a2a.github.io/A2A/lat
 | [Resubscribe To Task Request](hooks/resubscribe_to_task_request.md) | On client to reconnect to an SSE stream for an ongoing task after a previous connection (from `message/stream` or an earlier `tasks/resubscribe`) was interrupted. | [Docs](https://google-a2a.github.io/A2A/specification/#77-tasksresubscribe) |
 
 
-## AOS in action Examples
+## ACS in action Examples
 ### Scenario: An Observed client Agent **A** asks sever agent **B** a question and guardian agent respond with allow
 
 #### 1. Client agent **A** prepares A2A `message/send` message 

--- a/docs/spec/instrument/a2a/hooks/cancel_task_request.md
+++ b/docs/spec/instrument/a2a/hooks/cancel_task_request.md
@@ -7,7 +7,7 @@ This hook **must** be used before the observed agent sends the A2A-compliant mes
 [`tasks/cancel`](specification.md#48-a2a-protocol-methods)
 
 #### 3. Reponse
-The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse-object) object.
+The response is an [`ACSSuccessResponse`](specification.md#51-acssuccessresponse-object) object.
 
 | Decision | Behavior |
 | :--------- | :---------- |
@@ -26,7 +26,7 @@ The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse
      }
    }
    ```
-#### 5. AOS payload
+#### 5. ACS payload
    ```json
    {
     "jsonrpc": "2.0",
@@ -100,7 +100,7 @@ This hook **must** be used before the observed agent receives the A2A-compliant 
 [`tasks/cancel`](specification.md#48-a2a-protocol-methods)
 
 #### 3. Reponse
-The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse-object) object.
+The response is an [`ACSSuccessResponse`](specification.md#51-acssuccessresponse-object) object.
 
 | Decision | Behavior |
 | :--------- | :---------- |
@@ -119,7 +119,7 @@ The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse
      }
    }
    ```
-#### 5. AOS payload
+#### 5. ACS payload
    ```json
    {
     "jsonrpc": "2.0",

--- a/docs/spec/instrument/a2a/hooks/get_task_push_notification_config_request.md
+++ b/docs/spec/instrument/a2a/hooks/get_task_push_notification_config_request.md
@@ -6,7 +6,7 @@ This hook **must** be used before the observed agent sends the A2A-compliant mes
 [`tasks/pushNotificationConfig/get`](specification.md#48-a2a-protocol-methods)
 
 #### 3. Reponse
-The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse-object) object.
+The response is an [`ACSSuccessResponse`](specification.md#51-acssuccessresponse-object) object.
 
 | Decision | Behavior |
 | :--------- | :---------- |
@@ -25,7 +25,7 @@ The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse
      }
    }
    ```
-#### 5. AOS payload
+#### 5. ACS payload
    ```json
    {
     "jsonrpc": "2.0",
@@ -98,7 +98,7 @@ This hook **must** be used before the observed server agent receives the A2A-com
 [`tasks/pushNotificationConfig/get`](specification.md#48-a2a-protocol-methods)
 
 #### 3. Reponse
-The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse-object) object.
+The response is an [`ACSSuccessResponse`](specification.md#51-acssuccessresponse-object) object.
 
 | Decision | Behavior |
 | :--------- | :---------- |
@@ -117,7 +117,7 @@ The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse
      }
    }
    ```
-#### 5. AOS payload
+#### 5. ACS payload
    ```json
    {
     "jsonrpc": "2.0",

--- a/docs/spec/instrument/a2a/hooks/get_task_request.md
+++ b/docs/spec/instrument/a2a/hooks/get_task_request.md
@@ -7,7 +7,7 @@ This hook **must** be used before the observed agent sends the A2A-compliant mes
 [`tasks/get`](specification.md#48-a2a-protocol-methods)
 
 #### 3. Reponse
-The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse-object) object.
+The response is an [`ACSSuccessResponse`](specification.md#51-acssuccessresponse-object) object.
 
 | Decision | Behavior |
 | :--------- | :---------- |
@@ -29,7 +29,7 @@ The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse
      }
    }
    ```
-#### 5. AOS payload
+#### 5. ACS payload
    ```json
    {
     "jsonrpc": "2.0",
@@ -104,7 +104,7 @@ This hook **must** be used before the observed agent processes the A2A-compliant
 [`tasks/get`](specification.md#48-a2a-protocol-methods)
 
 #### 3. Reponse
-The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse-object) object.
+The response is an [`ACSSuccessResponse`](specification.md#51-acssuccessresponse-object) object.
 
 | Decision | Behavior |
 | :--------- | :---------- |
@@ -126,7 +126,7 @@ The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse
      }
    }
    ```
-#### 5. AOS payload
+#### 5. ACS payload
    ```json
    {
     "jsonrpc": "2.0",

--- a/docs/spec/instrument/a2a/hooks/resubscribe_to_task_request.md
+++ b/docs/spec/instrument/a2a/hooks/resubscribe_to_task_request.md
@@ -7,7 +7,7 @@ This hook **must** be used before the observed agent sends the A2A-compliant mes
 [`tasks/resubscribe`](specification.md#48-a2a-protocol-methods)
 
 #### 3. Reponse
-The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse-object) object.
+The response is an [`ACSSuccessResponse`](specification.md#51-acssuccessresponse-object) object.
 
 | Decision | Behavior |
 | :--------- | :---------- |
@@ -26,7 +26,7 @@ The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse
      }
    }
    ```
-#### 5. AOS payload
+#### 5. ACS payload
    ```json
    {
     "jsonrpc": "2.0",
@@ -100,7 +100,7 @@ This hook **must** be used before the observed agent processes the A2A-compliant
 [`tasks/resubscribe`](specification.md#48-a2a-protocol-methods)
 
 #### 3. Reponse
-The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse-object) object.
+The response is an [`ACSSuccessResponse`](specification.md#51-acssuccessresponse-object) object.
 
 | Decision | Behavior |
 | :--------- | :---------- |
@@ -119,7 +119,7 @@ The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse
      }
    }
    ```
-#### 5. AOS payload
+#### 5. ACS payload
    ```json
    {
     "jsonrpc": "2.0",

--- a/docs/spec/instrument/a2a/hooks/send_message_request.md
+++ b/docs/spec/instrument/a2a/hooks/send_message_request.md
@@ -8,7 +8,7 @@ This hook **must** be used before the observed agent sends the A2A-compliant mes
 [`message/send`](specification.md#48-a2a-protocol-methods)
 
 #### 3. Reponse
-The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse-object) object.
+The response is an [`ACSSuccessResponse`](specification.md#51-acssuccessresponse-object) object.
 
 | Decision | Behavior |
 | :--------- | :---------- |
@@ -38,7 +38,7 @@ The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse
    }
    ```
 
-#### 5. AOS payload
+#### 5. ACS payload
    ```json
    {
         "jsonrpc": "2.0",
@@ -122,7 +122,7 @@ This hook **must** be used before the observed agent processes the A2A-compliant
 [`message/send`](specification.md#48-a2a-protocol-methods)
 
 #### 3. Reponse
-The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse-object) object.
+The response is an [`ACSSuccessResponse`](specification.md#51-acssuccessresponse-object) object.
 
 | Decision | Behavior |
 | :--------- | :---------- |
@@ -151,7 +151,7 @@ The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse
      }
    }
    ```
-#### 5. AOS payload
+#### 5. ACS payload
    ```json
    {
         "jsonrpc": "2.0",

--- a/docs/spec/instrument/a2a/hooks/set_task_push_notification_config_request.md
+++ b/docs/spec/instrument/a2a/hooks/set_task_push_notification_config_request.md
@@ -7,7 +7,7 @@ This hook **must** be used before the observed agent sends the A2A-compliant mes
 [`tasks/pushNotificationConfig/get`](specification.md#48-a2a-protocol-methods)
 
 #### 6.3. Reponse
-The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse-object) object.
+The response is an [`ACSSuccessResponse`](specification.md#51-acssuccessresponse-object) object.
 
 | Decision | Behavior |
 | :--------- | :---------- |
@@ -30,7 +30,7 @@ The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse
      }
    }
    ```
-#### 5. AOS payload
+#### 5. ACS payload
    ```json
    {
     "jsonrpc": "2.0",
@@ -107,7 +107,7 @@ This hook **must** be used before the observed agent processes the A2A-compliant
 [`tasks/pushNotificationConfig/get`](specification.md#48-a2a-protocol-methods)
 
 #### 6.3. Reponse
-The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse-object) object.
+The response is an [`ACSSuccessResponse`](specification.md#51-acssuccessresponse-object) object.
 
 | Decision | Behavior |
 | :--------- | :---------- |
@@ -130,7 +130,7 @@ The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse
      }
    }
    ```
-#### 5. AOS payload
+#### 5. ACS payload
    ```json
    {
     "jsonrpc": "2.0",

--- a/docs/spec/instrument/a2a/hooks/stream_message_request.md
+++ b/docs/spec/instrument/a2a/hooks/stream_message_request.md
@@ -8,7 +8,7 @@ This hook **must** be used before the observed agent sends the A2A-compliant mes
 
 
 #### 3. Reponse
-The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse-object) object.
+The response is an [`ACSSuccessResponse`](specification.md#51-acssuccessresponse-object) object.
 
 | Decision | Behavior |
 | :--------- | :---------- |
@@ -50,7 +50,7 @@ The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse
   }
 }
    ```
-#### 5. AOS payload
+#### 5. ACS payload
    ```json
 {
     "jsonrpc": "2.0",
@@ -147,7 +147,7 @@ This hook **must** be used before the observed agent processes the A2A-compliant
 
 
 #### 3. Reponse
-The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse-object) object.
+The response is an [`ACSSuccessResponse`](specification.md#51-acssuccessresponse-object) object.
 
 | Decision | Behavior |
 | :--------- | :---------- |
@@ -189,7 +189,7 @@ The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse
   }
 }
    ```
-#### 5. AOS payload
+#### 5. ACS payload
    ```json
 {
     "jsonrpc": "2.0",

--- a/docs/spec/instrument/extend_mcp.md
+++ b/docs/spec/instrument/extend_mcp.md
@@ -3,25 +3,25 @@
 ## MCP protocol
 The Model Context Protocol ([MCP](https://modelcontextprotocol.io/introduction)) is an open standard that simplifies how AI models, particularly Large Language Models (LLMs) and agents, interact with external data sources, tools, and APIs. It's designed to provide a standardized way for AI agents to connect with the real world, making it easier to build AI applications that can access and use external information.<br><br>
 MCP is gaining popularity world-wide and is being adopted and integrated almost everywhere, security and observability must be implemented to prevent unwanted bad consequences.<br>
-In the same manner as AOS standardize security for non-standardize access and use of tools and data, it also extends MCP protocol to allow secure usage and implement security controls.
+In the same manner as ACS standardize security for non-standardize access and use of tools and data, it also extends MCP protocol to allow secure usage and implement security controls.
 
 ## MCP support
 
-AOS extension for MCP is used as a **transport** for MCP communications between the agent and the guardian agent. Meaning AOS understands and delivers MCP message as is.<br>
+ACS extension for MCP is used as a **transport** for MCP communications between the agent and the guardian agent. Meaning ACS understands and delivers MCP message as is.<br>
 Securing MCP means securing outbound and inbound communications/messages from the agent (using MCP client) to the MCP server and vice versa.<br> 
 
 #### To extend MCP protocol:
-1. Agents using MCP ***must*** use AOS as a transport protocol to deliver MCP messages to the guardian agent using [MCP protocol hooks](hooks.md#mcp-protocol-hooks).
-2. Agents using MCP ***must*** understand and enforce AOS responses.
+1. Agents using MCP ***must*** use ACS as a transport protocol to deliver MCP messages to the guardian agent using [MCP protocol hooks](hooks.md#mcp-protocol-hooks).
+2. Agents using MCP ***must*** understand and enforce ACS responses.
 
 #### The following flow explains how this should be done:
 1. Agent **A** prepares (using MCP client) MCP-compliant message.
-2. Agent **A** uses AOS as a transport to send the message to the guardian agent.
+2. Agent **A** uses ACS as a transport to send the message to the guardian agent.
 3. The guardian agent understands and processes the MCP transported message and send the result back to agent **A**.
 4. Agent **A** interprets and enforces the response from guardian agent.
 5. In case response is `allow`, agent **A** sends the MCP message to MCP server.
 6. MCP server processes the message and sends back to agent **A** the response.
-7. Agent **A** uses AOS as a transport to send the MCP response to the guardian agent.
+7. Agent **A** uses ACS as a transport to send the MCP response to the guardian agent.
 8. The guardian agent understands and processes the MCP transported response and send the result back to agent **A**.
 9. Agent **A** interprets and enforces the response from guardian agent.
 

--- a/docs/spec/instrument/hooks.md
+++ b/docs/spec/instrument/hooks.md
@@ -1,6 +1,6 @@
 # Supported hooks
 
-The supported hooks intervent the agent's workflow and interactions with the environment (see [Agent Environment Overview](../topics/core_concepts.md#agent-environment-overview)), to seamlessly expose the interaction data through the AOS standard.
+The supported hooks intervent the agent's workflow and interactions with the environment (see [Agent Environment Overview](../topics/core_concepts.md#agent-environment-overview)), to seamlessly expose the interaction data through the ACS standard.
 
 | Components | When | Native support | Protocols
 |--|--|--|--|
@@ -30,7 +30,7 @@ This hook should be used **after** the content is extracted from the trigger and
 [`steps/agentTrigger`](specification.md#41-stepsagenttrigger)
 
 ### 1.3. Reponse
-The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse-object) object.
+The response is an [`ACSSuccessResponse`](specification.md#51-acssuccessresponse-object) object.
 
 | Decision | Behavior |
 | :--------- | :---------- |
@@ -96,7 +96,7 @@ This hook should be used **after** the inputs are extracted and **before** the t
 [`steps/toolCallRequest`](specification.md#46-stepstoolcallrequest)
 
 ### 2.3. Reponse
-The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse-object) object.
+The response is an [`ACSSuccessResponse`](specification.md#51-acssuccessresponse-object) object.
 
 | Decision | Behavior |
 | :--------- | :---------- |
@@ -159,7 +159,7 @@ This hook should be used **before** the tool result is processed.
 [`steps/toolCallResult`](specification.md#46-stepstoolcallresult)
 
 ### 3.3. Reponse
-The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse-object) object.
+The response is an [`ACSSuccessResponse`](specification.md#51-acssuccessresponse-object) object.
 
 | Decision | Behavior |
 | :--------- | :---------- |
@@ -218,7 +218,7 @@ For this hook `role` **MUST** be `user` (see example).
 
 
 ### 4.3. Reponse
-The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse-object) object.
+The response is an [`ACSSuccessResponse`](specification.md#51-acssuccessresponse-object) object.
 
 | Decision | Behavior |
 | :--------- | :---------- |
@@ -283,7 +283,7 @@ This hook should be used **after** memory store is retrieved and **before** it i
 
 
 ### 5.3. Reponse
-The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse-object) object.
+The response is an [`ACSSuccessResponse`](specification.md#51-acssuccessresponse-object) object.
 
 | Decision | Behavior |
 | :--------- | :---------- |
@@ -343,7 +343,7 @@ This hook should be used **after** knowledge is retrieved and **before** it gets
 
 
 ### 6.3. Reponse
-The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse-object) object.
+The response is an [`ACSSuccessResponse`](specification.md#51-acssuccessresponse-object) object.
 
 | Decision | Behavior |
 | :--------- | :---------- |
@@ -418,7 +418,7 @@ This hook should be used **before** the memory store is updated. <br>
 
 
 ### 7.3. Reponse
-The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse-object) object.
+The response is an [`ACSSuccessResponse`](specification.md#51-acssuccessresponse-object) object.
 
 | Decision | Behavior |
 | :--------- | :---------- |
@@ -481,7 +481,7 @@ For this hook `role` **MUST** be `agent` (see example).
 
 
 ### 8.3. Reponse
-The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse-object) object.
+The response is an [`ACSSuccessResponse`](specification.md#51-acssuccessresponse-object) object.
 
 | Decision | Behavior |
 | :--------- | :---------- |
@@ -559,7 +559,7 @@ This hook should be used **before** the agent sends MCP-compliant message to the
 
 
 ### 11.3. Reponse
-The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse-object) object.
+The response is an [`ACSSuccessResponse`](specification.md#51-acssuccessresponse-object) object.
 
 | Decision | Behavior |
 | :--------- | :---------- |
@@ -601,7 +601,7 @@ This hook should be used **before** the agent processes the MCP received message
 
 
 ### 12.3. Reponse
-The response is an [`AOSSuccessResponse`](specification.md#51-aossuccessresponse-object) object.
+The response is an [`ACSSuccessResponse`](specification.md#51-acssuccessresponse-object) object.
 
 | Decision | Behavior |
 | :--------- | :---------- |

--- a/docs/spec/instrument/specification.md
+++ b/docs/spec/instrument/specification.md
@@ -1,10 +1,10 @@
-# AOS Specification
+# ACS Specification
 
 **Version:** `0.1.0`
 
 ## 1. Core concepts
 - **Guardian Agent**: An agent that monitors other agents behavior for anomalous and risky decisions.
-- **Agent**: An agent that implements AOS-compliant HTTP endpoints, sending data and providing visibility into its plans, reasoning and context. Also understands AOS responses and enforces results.
+- **Agent**: An agent that implements ACS-compliant HTTP endpoints, sending data and providing visibility into its plans, reasoning and context. Also understands ACS responses and enforces results.
 - **Session**: A session is a scoped unit of interaction, starting when an agent is activated (by user or environment) and ending when the task or interaction is complete. The session consists of turns, where turn is a single end to end loop between user and agent.
 - **Step**: A step is a single unit of action or decision taken by the agent as part of its reasoning or execution process. It can be a user message,  tool/function call, memory operation (retrieve or store context), knowledge retrieval etc. 
 - **A2A Message**: A2A-protocol message captured between agents communication.
@@ -15,18 +15,18 @@
 
 ### 2.1. Transport Protocol
 
-- AOS communication **MUST** occur over **HTTP(S)**.
+- ACS communication **MUST** occur over **HTTP(S)**.
 
 ### 2.2. Data Format
 
-AOS uses **[JSON-RPC 2.0](https://www.jsonrpc.org/specification)** as the payload format for all requests and responses
+ACS uses **[JSON-RPC 2.0](https://www.jsonrpc.org/specification)** as the payload format for all requests and responses
 
 - Agent requests and guardian agent responses **MUST** adhere to the JSON-RPC 2.0 specification.
 - The `Content-Type` header for HTTP requests and responses containing JSON-RPC payloads **MUST** be `application/json`.
 
 
 ## 3. Standard Data Objects
-These objects define the structure of data exchanged within the JSON-RPC methods of AOS.
+These objects define the structure of data exchanged within the JSON-RPC methods of ACS.
 
 
 ### 3.1. `Agent` Object
@@ -338,15 +338,15 @@ Represents an organization. Used in: `Agent` as the owning organization of the a
 
 ### 3.12. JSON-RPC Structures
 
-AOS adheres to the standard [JSON-RPC 2.0](https://www.jsonrpc.org/specification) structures for requests and responses.
+ACS adheres to the standard [JSON-RPC 2.0](https://www.jsonrpc.org/specification) structures for requests and responses.
 
 #### 3.12.1. `JSONRPCRequest` Object
 
-All AOS method calls are encapsulated in a JSON-RPC Request object.
+All ACS method calls are encapsulated in a JSON-RPC Request object.
 
 - `jsonrpc`: A String specifying the version of the JSON-RPC protocol. **MUST** be exactly `"2.0"`.
 - `method`: A String containing the name of the method to be invoked (e.g., `"steps/knowledge"`, `"messages/mcp"`).
-- `params`: A Structured value that holds the parameter values to be used during the invocation of the method. This member **MAY** be omitted if the method expects no parameters. AOS methods typically use an `object` for `params`.
+- `params`: A Structured value that holds the parameter values to be used during the invocation of the method. This member **MAY** be omitted if the method expects no parameters. ACS methods typically use an `object` for `params`.
 - `id`: An identifier established by the Client that **MUST** contain a String or Number(Integer) value. The Guardian Agent **MUST** reply with the same value in the Response object. This member is used to correlate the context between the two request and response objects.
 
 #### 3.12.2. `JSONRPCResponse` Object
@@ -491,12 +491,12 @@ Object representing an agent signature as an agent identifier
 
 
 ## 4. Protocol RPC Methods
-All AOS RPC methods are invoked by the agent by sending an HTTP POST request to the guardian agent. The body of the HTTP POST request **MUST** be a `JSONRPCRequest` object, and the `Content-Type` header **MUST** be `application/json`.
+All ACS RPC methods are invoked by the agent by sending an HTTP POST request to the guardian agent. The body of the HTTP POST request **MUST** be a `JSONRPCRequest` object, and the `Content-Type` header **MUST** be `application/json`.
 
 The guardian's agent HTTP response body **MUST** be a `JSONRPCResponse` object. The `Content-Type` for JSON-RPC responses is `application/json`.<br>
 
 Most of the protocol methods refer to steps within the agent's workflow: tool call, knowledge, memory etc.<br>
-AOS also supports industial standards for Agent to Agent communication (A2A protocol) and tool call and context (MCP protocol).
+ACS also supports industial standards for Agent to Agent communication (A2A protocol) and tool call and context (MCP protocol).
 
 ### 4.1. steps/agentTrigger
 This is the first step that activates or triggers the agent as a result or a response to an event.<br>
@@ -512,7 +512,7 @@ This method should be used after the agent's input is extracted from the trigger
 | `trigger` | [`AgentTrigger`](#36-agenttrigger-object) | Yes       | The trigger that activated the agent.                        |
 
 
-#### 4.1.2. **Response on success**: [`AOSSuccessResponse`](#51-AOSSuccessResponse-object).
+#### 4.1.2. **Response on success**: [`ACSSuccessResponse`](#51-ACSSuccessResponse-object).
 #### 4.1.3. **Response on failure**: [`JSONRPCErrorResponse`](#313-jsonrpcerrorresonse-object).
 
 
@@ -532,7 +532,7 @@ There are many retrieval techniques including semantic search (embedding-based s
 | `reasoning`       | `string`                               | No      | Agent's reasoning. |
 
 
-#### 4.2.2. **Response on success**: [`AOSSuccessResponse`](#51-AOSsuccessresponse-object).
+#### 4.2.2. **Response on success**: [`ACSSuccessResponse`](#51-ACSsuccessresponse-object).
 #### 4.2.3. **Response on failure**: [`JSONRPCErrorResponse`](#313-jsonrpcerrorresonse-object).
 
 ### 4.3. steps/memoryStore
@@ -548,7 +548,7 @@ Mostly, interaction history or a summary is stored to the memory store.
 | `reasoning`       | `string`                               | No      | Agent's reasoning. |
 
 
-#### 4.3.2. **Response on success**: [`AOSSuccessResponse`](#51-AOSsuccessresponse-object).
+#### 4.3.2. **Response on success**: [`ACSSuccessResponse`](#51-ACSsuccessresponse-object).
 #### 4.3.3. **Response on failure**: [`JSONRPCErrorResponse`](#313-jsonrpcerrorresonse-object).
 
 
@@ -566,7 +566,7 @@ This context is passed alongside with the agent's instructions(system prompt), u
 | `reasoning`       | `string`                               | No      | Agent's reasoning. |
 
 
-#### 4.4.2. **Response on success**: [`AOSSuccessResponse`](#51-AOSsuccessresponse-object).
+#### 4.4.2. **Response on success**: [`ACSSuccessResponse`](#51-ACSsuccessresponse-object).
 #### 4.4.3. **Response on failure**: [`JSONRPCErrorResponse`](#313-jsonrpcerrorresonse-object).
 
 
@@ -587,7 +587,7 @@ A message with `system` role represents a message from the system, such as guard
 | `reasoning`       | `string`                               | No      | Agent's reasoning. Should be used with `agent` or `system` message. |
 
 
-#### 4.5.2. **Response on success**: [`AOSSuccessResponse`](#51-AOSsuccessresponse-object).
+#### 4.5.2. **Response on success**: [`ACSSuccessResponse`](#51-ACSsuccessresponse-object).
 #### 4.5.3. **Response on failure**: [`JSONRPCErrorResponse`](#313-jsonrpcerrorresonse-object).
 
 
@@ -606,7 +606,7 @@ This method should be used after tool inputs are inferred by the LLM and before 
 
 
 
-#### 4.5.2. **Response on success**: [`AOSSuccessResponse`](#51-AOSsuccessresponse-object).
+#### 4.5.2. **Response on success**: [`ACSSuccessResponse`](#51-ACSsuccessresponse-object).
 #### 4.5.3. **Response on failure**: [`JSONRPCErrorResponse`](#313-jsonrpcerrorresonse-object).
 
 ### 4.6. steps/toolCallResult
@@ -629,7 +629,7 @@ This method should be used after tool is completed and before the result goes ba
 | `isError` |`boolean`| Yes       | Whether tool completed successfully or resulted in an error.                       |
 
 
-#### 4.6.2. **Response on success**: [`AOSSuccessResponse`](#51-AOSsuccessresponse-object).
+#### 4.6.2. **Response on success**: [`ACSSuccessResponse`](#51-ACSsuccessresponse-object).
 #### 4.6.3. **Response on failure**: [`JSONRPCErrorResponse`](#313-jsonrpcerrorresonse-object).
 
 ### 4.7. ping
@@ -649,7 +649,7 @@ This method is used by the agent to ensure that guardian agent is alive.
 #### 4.7.3. **Response on failure**: [`JSONRPCErrorResponse`](#313-jsonrpcerrorresonse-object).
 
 ### 4.8. A2A Requests
-Every [A2A](https://developers.googleblog.com/en/a2a-a-new-era-of-agent-interoperability/) protocol method (request) has its corresponding method in AOS. The structure of these methods are similar and comply with JRPC request structure.<br>
+Every [A2A](https://developers.googleblog.com/en/a2a-a-new-era-of-agent-interoperability/) protocol method (request) has its corresponding method in ACS. The structure of these methods are similar and comply with JRPC request structure.<br>
 For client agent, these methods should be used before sending A2A request to a server (remote) agent to monitor outbound communications.<br>
 For server agent, these methods should be used before processing A2A request from client agent to monitor inbound communications.<br>
 Read more about A2A support in [extend_a2a](../instrument/a2a/extend_a2a.md).
@@ -676,11 +676,11 @@ Read more about A2A support in [extend_a2a](../instrument/a2a/extend_a2a.md).
 - `tasks/get`
 
 
-#### 4.8.3. **Response on success**: [`AOSSuccessResponse`](#51-AOSsuccessresponse-object).
+#### 4.8.3. **Response on success**: [`ACSSuccessResponse`](#51-ACSsuccessresponse-object).
 #### 4.8.4. **Response on failure**: [`JSONRPCErrorResponse`](#313-jsonrpcerrorresonse-object).
 
 ### 4.9. A2A Responses
-Every response of [A2A supported methods](#482-a2a-supported-methods) from server agent has its corresponding AOS request.<br>
+Every response of [A2A supported methods](#482-a2a-supported-methods) from server agent has its corresponding ACS request.<br>
 
 For client agents, these methods should be used before the response from the server agent is processed by the client observed agent to monitor inbound communications.<br>
 For server agents, these methods should be used before the response the response is sent back to the client agent to monitor outbound communications.<br>
@@ -697,7 +697,7 @@ Read more about A2A support in [extend_a2a](../instrument/a2a/extend_a2a.md).
 | `payload`       | `object`                               | Yes      | A2A raw JSON message (response). |
 
 
-#### 4.9.2. **Response on success**: [`AOSSuccessResponse`](#51-AOSsuccessresponse-object).
+#### 4.9.2. **Response on success**: [`ACSSuccessResponse`](#51-ACSsuccessresponse-object).
 #### 4.9.3. **Response on failure**: [`JSONRPCErrorResponse`](#313-jsonrpcerrorresonse-object).
 
 
@@ -716,20 +716,20 @@ Read more about MCP support in [extend_mcp](../instrument/extend_mcp.md).
 | `message`       | `object`                               | Yes      | MCP-compliant message. |
 | `reasoning`       | `string`                               | No      | Agent's reasoning. |
 
-#### 4.10.2. **Response on success**: [`AOSSuccessResponse`](#51-AOSsuccessresponse-object).
+#### 4.10.2. **Response on success**: [`ACSSuccessResponse`](#51-ACSsuccessresponse-object).
 #### 4.10.3. **Response on failure**: [`JSONRPCErrorResponse`](#313-jsonrpcerrorresonse-object).
 
 
 ## 5. Responses
 
-### 5.1. `AOSSuccessResponse` Object
+### 5.1. `ACSSuccessResponse` Object
 | Field Name      | Type                                                            | Required | Description                                                        |
 | :-------------- | :-------------------------------------------------------------- | :------- | :----------------------------------------------------------------- |
 | `id`                   | `string` \| `integer`  | Yes       | Same id as the id in the correlated request. |
 | `jsonrpc`                   |`"2.0"` (literal)| Yes       | JSON-RPC version string. |
-| `result`                   |[`AOSSuccessResult`](#511-AOSsuccessresult-object)| Yes       | Success result. |
+| `result`                   |[`ACSSuccessResult`](#511-ACSsuccessresult-object)| Yes       | Success result. |
 
-#### 5.1.1. `AOSSuccessResult` Object
+#### 5.1.1. `ACSSuccessResult` Object
 
 | Field Name      | Type                                                            | Required | Description                                                        |
 | :-------------- | :-------------------------------------------------------------- | :------- | :----------------------------------------------------------------- |
@@ -738,7 +738,7 @@ Read more about MCP support in [extend_mcp](../instrument/extend_mcp.md).
 | `reasonCode`                   | `string`[] | No       | Timestamp (UTC recommended). |
 | `message`                   | `string`| Yes       | Human readable message explaining the decision. |
 | `data`                   | `Record<string, any>` | No       | Additional key-value data. |
-| `modifiedRequest`                   | `AOSRequest` | No       | Modified request. This is relevant when decision is `modify`. |
+| `modifiedRequest`                   | `ACSRequest` | No       | Modified request. This is relevant when decision is `modify`. |
 
 ### 5.2.`JSONRPCErrorResponse` Object
 | Field Name      | Type                                                            | Required | Description                                                        |
@@ -768,17 +768,17 @@ Read more about MCP support in [extend_mcp](../instrument/extend_mcp.md).
 
 ## 6. Error Handling
 
-AOS uses standard [JSON-RPC 2.0 error codes and structure](https://www.jsonrpc.org/specification#error_object) for reporting errors. Errors are returned in the `error` member of the `JSONRPCErrorResponse` object. See [`JSONRPCError` Object definition](#313-jsonrpcerror-object).
+ACS uses standard [JSON-RPC 2.0 error codes and structure](https://www.jsonrpc.org/specification#error_object) for reporting errors. Errors are returned in the `error` member of the `JSONRPCErrorResponse` object. See [`JSONRPCError` Object definition](#313-jsonrpcerror-object).
 
 ### 6.1. Standard JSON-RPC Errors
 
 These are standard codes defined by the JSON-RPC 2.0 specification.
 
-| Code                 | JSON-RPC Spec Meaning | Typical AOS `message`     | Description                                                                                  |
+| Code                 | JSON-RPC Spec Meaning | Typical ACS `message`     | Description                                                                                  |
 | :------------------- | :-------------------- | :------------------------ | :------------------------------------------------------------------------------------------- |
 | `-32700`             | Parse error (JSONParseError)          | Invalid JSON payload      | Server received JSON that was not well-formed.                                               |
 | `-32600`             | Invalid Request (InvalidRequestError)      | Invalid JSON-RPC Request  | The JSON payload was valid JSON, but not a valid JSON-RPC Request object.                    |
-| `-32601`             | Method not found (MethodNotFoundError)      | Method not found          | The requested AOS RPC `method` (e.g., `"steps/foo"`) does not exist or is not supported.     |
+| `-32601`             | Method not found (MethodNotFoundError)      | Method not found          | The requested ACS RPC `method` (e.g., `"steps/foo"`) does not exist or is not supported.     |
 | `-32602`             | Invalid params (InvalidParamsError)        | Invalid method parameters | The `params` provided for the method are invalid (e.g., wrong type, missing required field). |
 | `-32603`             | Internal error (InternalError)       | Internal server error     | An unexpected error occurred on the server during processing.                                |
-| `-32000` to `-32099` | Server error          | _(Server-defined)_        | Reserved for implementation-defined server-errors. AOS-specific errors use this range.       |
+| `-32000` to `-32099` | Server error          | _(Server-defined)_        | Reserved for implementation-defined server-errors. ACS-specific errors use this range.       |

--- a/docs/spec/trace/OCSF/implementation_examples.md
+++ b/docs/spec/trace/OCSF/implementation_examples.md
@@ -1,6 +1,6 @@
 # OCSF Implementation Examples
 
-This document provides detailed implementation examples and patterns for AOS's OCSF implementation.
+This document provides detailed implementation examples and patterns for ACS's OCSF implementation.
 
 ## Dependencies
 

--- a/docs/spec/trace/README.md
+++ b/docs/spec/trace/README.md
@@ -1,11 +1,11 @@
-# Agent Observability Standard - Trace
+# Agent Control Standard - Trace
 
 AI agents make autonomous decisions that impact business outcomes. Without observability, enterprises can't understand, trust, or control these decisions.
 
 **Transform agent black boxes into transparent, auditable systems through comprehensive tracing.**
 
-!!! info "AOS Extends Industry Standards"
-    We already have great observability standards, so AOS doesn't introduce a new one. Instead, it extends existing industry-proven standards: OpenTelemetry and OCSF to support AI agent-specific components.
+!!! info "ACS Extends Industry Standards"
+    We already have great observability standards, so ACS doesn't introduce a new one. Instead, it extends existing industry-proven standards: OpenTelemetry and OCSF to support AI agent-specific components.
 
 ## Why Agent Observability Matters
 
@@ -27,12 +27,12 @@ Modern agents orchestrate complex workflows: reasoning chains, tool execution, k
 
 ## How It Works
 
-AOS provides specification for detailed tracing of agent behavior. Traces are implemented via extensions of proven industry standards:
+ACS provides specification for detailed tracing of agent behavior. Traces are implemented via extensions of proven industry standards:
 
-| Standard | AOS Spec | Status |
+| Standard | ACS Spec | Status |
 |--|--|--|
-| [OpenTelemetry](https://opentelemetry.io/) | [AOS with OpenTelemetry](./extend_opentelemetry.md) | Working draft |
-| [OCSF](https://ocsf.io/) | [AOS with OCSF](./extend_ocsf.md) | Working draft |
+| [OpenTelemetry](https://opentelemetry.io/) | [ACS with OpenTelemetry](./extend_opentelemetry.md) | Working draft |
+| [OCSF](https://ocsf.io/) | [ACS with OCSF](./extend_ocsf.md) | Working draft |
 
 ## Read Next
 

--- a/docs/spec/trace/events.md
+++ b/docs/spec/trace/events.md
@@ -1,11 +1,11 @@
-# AOS Supported Events
+# ACS Supported Events
 
 Every agent action becomes observable. Every decision gets traced. Every communication leaves a trail.
 
-Agent Observability Standard (AOS) transforms opaque AI systems into transparent, auditable processes through standardized event emission. This document defines the canonical events that enable trust through visibility.
+Agent Control Standard (ACS) transforms opaque AI systems into transparent, auditable processes through standardized event emission. This document defines the canonical events that enable trust through visibility.
 
 ## Event Classification
-All observable actions in AOS are considered **Agent Steps**. Each step represents a single, traceable action taken by the agent or the system. To enhance explainability and provide a clear structure for analysis, these steps are classified into the following groups based on their purpose. This classification is for semantic grouping and does not imply a technical difference in the underlying event structure.
+All observable actions in ACS are considered **Agent Steps**. Each step represents a single, traceable action taken by the agent or the system. To enhance explainability and provide a clear structure for analysis, these steps are classified into the following groups based on their purpose. This classification is for semantic grouping and does not imply a technical difference in the underlying event structure.
 
 | Category | Description | Events |
 |----------|-------------|---------|

--- a/docs/spec/trace/extend_ocsf.md
+++ b/docs/spec/trace/extend_ocsf.md
@@ -1,10 +1,10 @@
-# AOS tracing with OCSF
+# ACS tracing with OCSF
 
 The Open Cybersecurity Schema Framework (OCSF) integration enables standardized security event logging for AI agent activities, making them compatible with existing SIEM and security monitoring tools.
 
 ## Overview
 
-AOS maps agent activities to OCSF event classes, providing:
+ACS maps agent activities to OCSF event classes, providing:
 
 - Standardized security event format
 - MCP & A2A Support out of the box
@@ -15,7 +15,7 @@ AOS maps agent activities to OCSF event classes, providing:
 
 ### Agent Activity Events
 
-AOS extends OCSF's API Activity class (6003) for agent-specific events.
+ACS extends OCSF's API Activity class (6003) for agent-specific events.
 
 Here's a basic example:
 
@@ -33,8 +33,8 @@ Here's a basic example:
   "metadata": {
     "version": "1.0.0",
     "product": {
-      "name": "AOS Security Layer",
-      "vendor_name": "AOS"
+      "name": "ACS Security Layer",
+      "vendor_name": "ACS"
     }
   },
   "actor": {
@@ -59,7 +59,7 @@ Here's a basic example:
   },
   "osint": [],
   "unmapped": {
-    "aos": {
+    "acs": {
       "tool_call": {
         "name": "database_query",
         "arguments": {
@@ -72,8 +72,8 @@ Here's a basic example:
           "name": "CustomerServiceAgent",
           "version": "1.0.0",
           "provider": {
-            "name": "AOS",
-            "url": "https://example.aos"
+            "name": "ACS",
+            "url": "https://example.acs"
           }
         },
         "session": {
@@ -115,8 +115,8 @@ Here's a basic example:
   "metadata": {
     "version": "1.0.0",
     "product": {
-      "name": "AOS Security Layer",
-      "vendor_name": "AOS"
+      "name": "ACS Security Layer",
+      "vendor_name": "ACS"
     },
     "correlation_uid": "exec-123"
   },
@@ -156,7 +156,7 @@ Here's a basic example:
   },
   "osint": [],
   "unmapped": {
-    "aos": {
+    "acs": {
       "step": {
         "id": "step-abc",
         "type": "toolCall",
@@ -189,8 +189,8 @@ Here's a basic example:
           "name": "CustomerServiceAgent",
           "version": "1.0.0",
           "provider": {
-            "name": "AOS",
-            "url": "https://example.aos"
+            "name": "ACS",
+            "url": "https://example.acs"
           }
         },
         "model": {
@@ -219,8 +219,8 @@ Here's a basic example:
   "metadata": {
     "version": "1.0.0",
     "product": {
-      "name": "AOS Security Layer",
-      "vendor_name": "AOS"
+      "name": "ACS Security Layer",
+      "vendor_name": "ACS"
     },
     "correlation_uid": "4bf92f3577b34da6a3ce929d0e0e4736"
   },
@@ -259,15 +259,15 @@ Here's a basic example:
     }
   },
   "unmapped": {
-    "aos": {
+    "acs": {
       "agent_context": {
         "agent": {
           "id": "planner-123",
           "name": "PlannerAgent",
           "version": "1.0.0",
           "provider": {
-            "name": "AOS",
-            "url": "https://example.aos"
+            "name": "ACS",
+            "url": "https://example.acs"
           }
         },
         "session": {

--- a/docs/spec/trace/extend_opentelemetry.md
+++ b/docs/spec/trace/extend_opentelemetry.md
@@ -1,8 +1,8 @@
-# AOS tracing with Open Telemetry
+# ACS tracing with Open Telemetry
 
-To thoroughly trace an AI agent, it is crucial to connect traces and events in a manner that accurately reflects the agent's atomic actions and its broader units of logical operation. This provides a transparent, step-by-step visualization of how an agent processes information, arrives at decisions, and executes tasks. The AOS schema offers a structured framework for defining these interactions, which can then be effectively mapped to OpenTelemetry concepts.
+To thoroughly trace an AI agent, it is crucial to connect traces and events in a manner that accurately reflects the agent's atomic actions and its broader units of logical operation. This provides a transparent, step-by-step visualization of how an agent processes information, arrives at decisions, and executes tasks. The ACS schema offers a structured framework for defining these interactions, which can then be effectively mapped to OpenTelemetry concepts.
 
-- **Mapping AOS Steps to OpenTelemetry Spans**: Each distinct step defined within AOS can be directly correlated with an OpenTelemetry span. For instance:
+- **Mapping ACS Steps to OpenTelemetry Spans**: Each distinct step defined within ACS can be directly correlated with an OpenTelemetry span. For instance:
     
     - `steps/message`: A span can be initiated when a user message is processed or when an agent generates a message. Attributes for this span would ideally include the message role, its content (potentially summarized or hashed to protect Personally Identifiable Information (PII)), and relevant IDs.
         
@@ -22,9 +22,9 @@ To thoroughly trace an AI agent, it is crucial to connect traces and events in a
         
     - Within this primary span, child spans can represent major logical phases such as `agent.plan` or individual turns within a conversation.
         
-    - Each "turn" (which can be identified by a `turnId` as per AOS ) can itself be a parent span.
+    - Each "turn" (which can be identified by a `turnId` as per ACS ) can itself be a parent span.
         
-    - Individual "steps" (identifiable by a `stepId` in AOS ) occurring within a turn, such as an LLM call followed by a tool call, then become child spans under the respective turn span. This structure aligns well with the `RequestContext` defined in AOS, which includes `agent`, `session`, `turnId`, and `stepId`.
+    - Individual "steps" (identifiable by a `stepId` in ACS ) occurring within a turn, such as an LLM call followed by a tool call, then become child spans under the respective turn span. This structure aligns well with the `RequestContext` defined in ACS, which includes `agent`, `session`, `turnId`, and `stepId`.
         
 - **Enriching Spans with Attributes from Agent Logic**:
     

--- a/docs/topics/ACS_in_action_example.md
+++ b/docs/topics/ACS_in_action_example.md
@@ -1,17 +1,17 @@
-# Illustrating AOS in Action
+# Illustrating ACS in Action
 
 Please read [Core Concepts](./core_concepts.md) if you haven't already.
 
 ## Overall process
 
 The following sequence diagram describes an example of MCP tool call request by an Observed Agent.
-Instrumented with AOS the Observed Agent communicates with a Guardian Agent.
+Instrumented with ACS the Observed Agent communicates with a Guardian Agent.
 
 ![Sequence Diagram](../assets/sequence_diagram.png "Sequence Diagram")
 
 The Guardian Agent has 3 roles:
 
-1. It should permit, deny or modify the request and send back its verdict by AOS
+1. It should permit, deny or modify the request and send back its verdict by ACS
 2. Sending a trace of the request for observability purpose using OpenTelemetry or OCSF
 3. Update it's bill-of-material with the new tool using CycloneDX, SWID or SPDX
 
@@ -21,9 +21,9 @@ The Guardian Agent has 3 roles:
 ```python
 # add here the MCP tool call format
 ```
-### Step 2: Agent AOS Request sending
+### Step 2: Agent ACS Request sending
 ```python
-# add here the AOS Request with the MCP tool call
+# add here the ACS Request with the MCP tool call
 ```
 ### Step 3: Guardian Agent sending a trace of the MCP Tool Call
 ```python
@@ -55,7 +55,7 @@ def restrict_to_mcp_servers():
 ```
 ### Step 5: Guardian Agent Sending a "Permitted" Response
 ```python
-# add here the AOS Response
+# add here the ACS Response
 ```
 ### Step 6: Guardian Agent Sending an updated BOM
 

--- a/docs/topics/core_concepts.md
+++ b/docs/topics/core_concepts.md
@@ -1,9 +1,9 @@
 # Core concepts
 
-AOS specifies the in-line _Hooks_ and out-of-band _Events_ that an agent need to support to be considered trustworthy.
+ACS specifies the in-line _Hooks_ and out-of-band _Events_ that an agent need to support to be considered trustworthy.
 Usings these events and hooks, _Observed Agents_ can be monitored and protected by a _Guardian Agent_.
 
-## Agent Observability Standard
+## Agent Control Standard
 
 To support an holistic view and security enforcement, the framework defines three components
 
@@ -50,11 +50,11 @@ The Guardian Agent enforces policies and enables tracing through the following:
 
 ## A2A and MCP
 
-AOS works even better when MCP and A2A are part of an Agent's environment.
+ACS works even better when MCP and A2A are part of an Agent's environment.
 It carries MCP and A2A intact, ensuring full compatibility and transparency.
 
-AOS also proposes security extensions for [MCP](../spec/instrument/extend_mcp.md) and [A2A](../spec/instrument/a2a/extend_a2a.md) for native observability support.
+ACS also proposes security extensions for [MCP](../spec/instrument/extend_mcp.md) and [A2A](../spec/instrument/a2a/extend_a2a.md) for native observability support.
 
 ## Read Next
 
-- [AOS in Action](./AOS_in_action_example.md)
+- [ACS in Action](./ACS_in_action_example.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,16 +1,16 @@
-site_name: Agent Observability Standard
+site_name: Agent Control Standard
 site_url: !ENV GITHUB_PAGES_URL
 site_description: >-
   An industry standard for building trustworthy AI agents - instrumentable, traceable and inspectable
    to enable enterprise-wide adoption with confidence.
 
 # Repository
-repo_name: trustworthyagents/aos
-repo_url: https://github.com/trustworthyagents/aos
+repo_name: Agent-Control-Standard/ACS
+repo_url: https://github.com/Agent-Control-Standard/ACS
 edit_uri: edit/dev/docs/
 
 # Copyright
-copyright: Copyright &copy; 2025 AOS
+copyright: Copyright &copy; 2025 ACS
 
 docs_dir: docs
 
@@ -58,19 +58,19 @@ extra:
   social:
     - icon: /fontawesome/regular/envelope
       name: Send us an email
-      link: mailto:aos@zenity.io
+      link: mailto:acs@zenity.io
 
 nav:
   - Trustworthy Agents: README.md
-  - AOS: aos.md
+  - ACS: acs.md
   - Topics:
     - Core concepts: topics/core_concepts.md
-    - AOS in Action: topics/AOS_in_action_example.md
+    - ACS in Action: topics/ACS_in_action_example.md
   - Specification:
     - Instrument:
       - Overview: spec/instrument/README.md
       - Supported Hooks: spec/instrument/hooks.md
-      - AOS specification: spec/instrument/specification.md
+      - ACS specification: spec/instrument/specification.md
       - Instrument MCP: spec/instrument/extend_mcp.md
       - Instrument A2A: spec/instrument/a2a/extend_a2a.md
     - Trace:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
-name = "aos"
+name = "acs"
 version = "0.1.0"
-description = "AOS Documentation"
+description = "ACS Documentation"
 requires-python = ">=3.8"
 dependencies = [ "mike>=1.2.0", "mkdocs-material>=9.6.14", "pymdown-extensions>=10.0.0",]

--- a/specification/ACS/acs_schema.json
+++ b/specification/ACS/acs_schema.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "AOS Schema",
-    "description": "JSON Schema for Agent Observability Standard",
+    "title": "ACS Schema",
+    "description": "JSON Schema for Agent Control Standard",
     "version": "0.1.0",
     "$defs": {
         "A2AFullAgentContext":{

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [[package]]
-name = "aos"
+name = "acs"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [


### PR DESCRIPTION
## Summary
- Renamed Agent Observability Standard → Agent Control Standard in all content
- Replaced AOS → ACS in filenames, directories, code examples, and references
- Updated URLs: aos.owasp.org → agentcontrolstandard.org
- Updated repo references to Agent-Control-Standard/ACS
- Renamed files: `docs/aos.md` → `acs.md`, `specification/AOS/` → `ACS/`, `AOS_in_action_example.md` → `ACS_in_action_example.md`

## Test plan
- [ ] Verify all documentation renders correctly on agentcontrolstandard.org
- [ ] Confirm no remaining AOS references via search
- [ ] Validate mkdocs.yml navigation paths resolve