### PR TITLE
Sync dev to main: rebrand finalization + tagline update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to ACS
 
-We're building trustworthy AI agents together. Your contributions make the future of agent observability possible.
+We're building trustworthy AI agents together. Your contributions make the future of agent observability and control possible.
 
 **Before spending lots of time on something, ask for feedback on your idea first!**
 
@@ -79,4 +79,4 @@ This guide is based on [github-contributing](https://raw.githubusercontent.com/s
 - **[GitHub Discussions](https://github.com/Agent-Control-Standard/ACS/discussions)**: Ask questions, share ideas
 - **[Issues](https://github.com/Agent-Control-Standard/ACS/issues)**: Report bugs, request features
 
-We're building the future of AI agent observability. Join us.
+We're building the future of AI agent observability and control. Join us.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ![ACS Banner](docs/assets/banner.png)
 
-**Making AI agents trustworthy by standardizing observability.**
+**Making AI agents trustworthy by standardizing observability and control.**
 
 ## Rational
 Agents must become trustworthy to enable widescale adoption.


### PR DESCRIPTION
## Summary
- Brings dev branch (containing the AOS→ACS rebrand and prior fixes) into main
- Includes new tagline update reflecting "observability and control" across README and CONTRIBUTING

## Test plan
- [x] README.md tagline reads "observability and control"
- [x] CONTRIBUTING.md intro and closing both reference "observability and control"
- [ ] CI passes on merged main