### PR TITLE
Fix placeholder URL, broken anchor, and typo in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The standard covers the following aspects
 
 We welcome community contributions to enhance and evolve ACS!
 
-- **Questions & Discussions:** Join our [GitHub Discussions](do we have github enterprise?).
+- **Questions & Discussions:** Join our [GitHub Discussions](https://github.com/Agent-Control-Standard/ACS/discussions).
 - **Issues & Feedback:** Report issues or suggest improvements via [GitHub Issues](https://github.com/Agent-Control-Standard/ACS/issues).
 - **Contribution Guide:** See our [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to contribute.
 

--- a/docs/acs.md
+++ b/docs/acs.md
@@ -7,8 +7,6 @@ They are an open book
 
 They have a dynamic bill-of-material, a clear audit trail and hard inline-controls.
 
-<!-- TODO: add diagram -->
-
 Trustworthiness of agents builds upon the foundation of existing standards (MCP and A2A), but provides value regardless. 
 It build upon cybersecurity and observability standards including OpenTelemetry, OCSF, CycloneDX, SPDX and SWID.
 

--- a/docs/spec/instrument/specification.md
+++ b/docs/spec/instrument/specification.md
@@ -455,7 +455,7 @@ Object representing the receiver agent in the A2A protocol communication
 ### 3.17. `Identity` Object
 Object representing identity in the context. This is a union object that can be one of the following:
 - [`User`](#310-user-object)
-- [`MachineIdentity`]()
+- [`MachineIdentity`](#3171-machineidentity-object)
 - [`AgentIdentity`](#318-agentidentity-object)
 
 
@@ -464,7 +464,7 @@ Object representing a machine identity
 
 | Field Name | Type      | Required | Description                                                                                                  |
 | :--------- | :-------- | :------- | :----------------------------------------------------------------------------------------------------------- |
-| `id`     | `striung` | Yes      | The unique identifier of the application or service. |
+| `id`     | `string` | Yes      | The unique identifier of the application or service. |
 | `name`     | `string`| Yes      | The name of the application or service. |
 | `organization`     | [`Organization`](#311-organization-object)[] | Yes      | The owning organization of the application or service. |
 | `metadata`                   | `Record<string, any>` | No       | Arbitrary key-value metadata associated with the identity. |


### PR DESCRIPTION
## Summary
- Replace `(do we have github enterprise?)` placeholder in README with the real [Discussions URL](https://github.com/Agent-Control-Standard/ACS/discussions)
- Remove stale `<!-- TODO: add diagram -->` comment in `docs/acs.md` (the page already carries a "Work in progress" admonition)
- Point empty `[MachineIdentity]()` link in `specification.md` at section 3.17.1, and fix `striung` → `string` typo on the same object's `id` field

## Test plan
- [x] `git diff` reviewed — three files, four targeted changes, no collateral edits
- [ ] MkDocs renders the spec page without broken anchor warnings (will verify post-merge on the deployed docs)