### PR TITLE
docs: conformance is a technical measure — it cannot attest human intent

### DIFF
--- a/tests/test_apply_governance.py
+++ b/tests/test_apply_governance.py
@@ -22,6 +22,7 @@ from apply_governance import (  # noqa: E402
     Ruleset,
     build_parser,
     collect_actions,
+    desired_board_status,
     desired_issues,
     desired_labels,
     desired_milestones,
@@ -29,6 +30,7 @@ from apply_governance import (  # noqa: E402
     desired_state,
     main,
     plan_actions,
+    plan_board_actions,
     plan_branch_actions,
     plan_default_branch_actions,
     plan_required_check_actions,
@@ -41,6 +43,25 @@ FORBIDDEN_ARGV_SUBSTRINGS = ("pr merge", "pr close", "pr edit", "label delete")
 
 FIVE_AXES = ("type:", "scope:", "status:", "priority:", "workstream:")
 STOCK_DEFAULTS = {"help wanted", "good first issue"}
+
+# Fake Status option ids for the board tests. Deliberately not the live project's real
+# ids, so a test that accidentally hardcoded a real id would still be caught by
+# test_board_option_ids_are_never_hardcoded_in_the_module below.
+BOARD_STATUS_OPTION_IDS = {
+    "Needs triage": "opt-triage",
+    "Deferred": "opt-deferred",
+    "Accepted": "opt-accepted",
+    "In progress": "opt-inprogress",
+    "Blocked": "opt-blocked",
+    "Done": "opt-done",
+}
+BOARD_PROJECT_ID = "PVT_test"
+BOARD_STATUS_FIELD_ID = "PVTSSF_test"
+
+# This project's real live Status option ids, captured once for the negative-hardcoding
+# assertion. Regenerated whenever a maintainer edits the field's options, which has
+# already happened once in this project's life (see apply_governance.py's board step).
+LIVE_BOARD_OPTION_IDS = ("035be0b0", "292b0c9f", "1ae0623e", "6e25e73d", "3f24090e", "b70371f3")
 
 
 # --- Label taxonomy -----------------------------------------------------------
@@ -326,6 +347,189 @@ def test_required_status_checks_parameters_contains_exactly_three_keys():
         )
 
 
+# --- Board status precedence -----------------------------------------------------
+#
+# Six rungs, highest first: state (Done) > status:blocked (Blocked) > open pull
+# request (In progress) > status:accepted (Accepted) > scope:deferred (Deferred) >
+# otherwise (Needs triage). The pull-request rung exists because an open pull
+# request is work in flight by definition, with or without a label: the live board
+# held nine open pull requests in In progress with no recognised label between them,
+# and an early version of this mapping would have swept all nine back out on the
+# first run.
+
+def test_desired_board_status_closed_or_merged_beats_every_label():
+    """The gotcha: a closed issue carrying status:accepted is Done, not Accepted."""
+    assert desired_board_status(("status:accepted",), "CLOSED", False) == "Done"
+    assert desired_board_status(("status:blocked", "status:accepted"), "CLOSED", False) == "Done"
+
+
+def test_desired_board_status_merged_pull_request_is_done():
+    """State still beats everything, including the pull-request rung."""
+    assert desired_board_status((), "MERGED", True) == "Done"
+
+
+def test_desired_board_status_blocked_beats_accepted():
+    """The gotcha: blocked-and-accepted resolves to Blocked, not Accepted."""
+    assert desired_board_status(("status:blocked", "status:accepted"), "OPEN", False) == "Blocked"
+
+
+def test_desired_board_status_blocked_pull_request_still_blocked():
+    """Proves the pull-request rung sits below Blocked: a blocked pull request reads
+    as Blocked, not In progress."""
+    assert desired_board_status(("status:blocked",), "OPEN", True) == "Blocked"
+
+
+def test_desired_board_status_open_pull_request_with_no_labels_is_in_progress():
+    """An open pull request needs no label to be work in flight."""
+    assert desired_board_status((), "OPEN", True) == "In progress"
+
+
+def test_desired_board_status_accepted():
+    assert desired_board_status(("status:accepted",), "OPEN", False) == "Accepted"
+
+
+def test_desired_board_status_deferred():
+    assert desired_board_status(("scope:deferred",), "OPEN", False) == "Deferred"
+
+
+def test_desired_board_status_otherwise_is_needs_triage():
+    assert desired_board_status((), "OPEN", False) == "Needs triage"
+
+
+def test_desired_board_status_unrecognized_labels_fall_through_to_needs_triage():
+    """An item with no recognised labels resolves to Needs triage, not a crash or a
+    silent match on some other rung."""
+    assert desired_board_status(("type:bug", "priority:P1"), "OPEN", False) == "Needs triage"
+
+
+# --- plan_board_actions: idempotence, add, set-status, and scope ------------------
+
+def _board_desired_items() -> list[dict]:
+    return [
+        {
+            "key": "1", "content_id": "I_1", "labels": ["status:accepted"],
+            "state": "OPEN", "is_pull_request": False,
+        },
+        {
+            "key": "2", "content_id": "I_2", "labels": ["scope:deferred"],
+            "state": "OPEN", "is_pull_request": False,
+        },
+        {
+            "key": "3", "content_id": "PR_3", "labels": ["status:accepted"],
+            "state": "MERGED", "is_pull_request": True,
+        },
+        {
+            "key": "4", "content_id": "PR_4", "labels": [],
+            "state": "OPEN", "is_pull_request": True,
+        },
+    ]
+
+
+def test_plan_board_actions_is_idempotent_against_matching_live_state():
+    desired = _board_desired_items()
+    live = [
+        {
+            "key": item["key"],
+            "item_id": f"PVTI_{item['key']}",
+            "status": desired_board_status(item["labels"], item["state"], item["is_pull_request"]),
+        }
+        for item in desired
+    ]
+    actions = plan_board_actions(
+        live, desired, BOARD_PROJECT_ID, BOARD_STATUS_FIELD_ID, BOARD_STATUS_OPTION_IDS
+    )
+    assert actions == []
+
+
+def test_plan_board_actions_against_empty_board_adds_one_action_per_open_item():
+    desired = [item for item in _board_desired_items() if item["state"] == "OPEN"]
+    actions = plan_board_actions(
+        [], desired, BOARD_PROJECT_ID, BOARD_STATUS_FIELD_ID, BOARD_STATUS_OPTION_IDS
+    )
+    assert len(actions) == len(desired)
+    for action in actions:
+        assert action.step == "board"
+        assert "addProjectV2ItemById" in " ".join(action.argv)
+
+
+def test_plan_board_actions_never_adds_a_closed_item_not_already_on_the_board():
+    """Backfilling a merged pull request that was never tracked is noise, per the
+    plan's scope note, so an empty board yields zero actions for it."""
+    desired = [item for item in _board_desired_items() if item["state"] != "OPEN"]
+    actions = plan_board_actions(
+        [], desired, BOARD_PROJECT_ID, BOARD_STATUS_FIELD_ID, BOARD_STATUS_OPTION_IDS
+    )
+    assert actions == []
+
+
+def test_plan_board_actions_wrong_status_yields_set_status_and_no_add():
+    desired = [
+        {
+            "key": "1", "content_id": "I_1", "labels": ["status:blocked"],
+            "state": "OPEN", "is_pull_request": False,
+        }
+    ]
+    live = [{"key": "1", "item_id": "PVTI_1", "status": "Needs triage"}]
+    actions = plan_board_actions(
+        live, desired, BOARD_PROJECT_ID, BOARD_STATUS_FIELD_ID, BOARD_STATUS_OPTION_IDS
+    )
+    assert len(actions) == 1
+    rendered = " ".join(actions[0].argv)
+    assert "updateProjectV2ItemFieldValue" in rendered
+    assert "addProjectV2ItemById" not in rendered
+
+
+def test_plan_board_actions_already_on_board_and_now_merged_moves_to_done():
+    """The drift this step exists to fix: a merged pull request sitting in a stale
+    status moves to Done rather than being skipped because it is closed."""
+    desired = [
+        {
+            "key": "3", "content_id": "PR_3", "labels": [],
+            "state": "MERGED", "is_pull_request": True,
+        }
+    ]
+    live = [{"key": "3", "item_id": "PVTI_3", "status": "In progress"}]
+    actions = plan_board_actions(
+        live, desired, BOARD_PROJECT_ID, BOARD_STATUS_FIELD_ID, BOARD_STATUS_OPTION_IDS
+    )
+    assert len(actions) == 1
+    assert BOARD_STATUS_OPTION_IDS["Done"] in actions[0].argv[-1]
+
+
+def test_plan_board_actions_leaves_an_open_issue_already_in_progress_alone():
+    """GitHub's built-in "Pull request linked to issue" workflow moves an issue to
+    In progress when a pull request links to it. Nothing in the label set records
+    that link, so reconciling this issue back to its label-derived column (Accepted,
+    here) would fight that workflow on every run. This proves the reconciler steps
+    aside instead of emitting a set-status action.
+    """
+    desired = [
+        {
+            "key": "5", "content_id": "I_5", "labels": ["status:accepted"],
+            "state": "OPEN", "is_pull_request": False,
+        }
+    ]
+    live = [{"key": "5", "item_id": "PVTI_5", "status": "In progress"}]
+    actions = plan_board_actions(
+        live, desired, BOARD_PROJECT_ID, BOARD_STATUS_FIELD_ID, BOARD_STATUS_OPTION_IDS
+    )
+    assert actions == []
+
+
+def test_board_option_ids_are_never_hardcoded_in_the_module():
+    """Option ids regenerate whenever the Status field's options are edited, which has
+    already happened once in this project's life. A hardcoded id is a bug waiting on
+    the next edit, so the module must fetch these at runtime instead."""
+    source = (REPO_ROOT / "tools" / "apply_governance.py").read_text(encoding="utf-8")
+    for option_id in LIVE_BOARD_OPTION_IDS:
+        assert option_id not in source, f"module source hardcodes board option id {option_id!r}"
+
+
+def test_board_is_an_automatable_step():
+    assert "board" in AUTOMATABLE_STEPS
+    assert "board" not in HUMAN_STEPS
+
+
 # --- plan_actions: idempotence and completeness ---------------------------------
 
 def _live_matching(desired) -> dict:
@@ -427,17 +631,35 @@ def _all_actions_for_safety_scan() -> list:
     sample" the safety property has to hold over.
     """
     desired = desired_state()
+    board_repo_items = _board_desired_items()
+
     matching_live = _live_matching(desired)
     matching_live["branches"] = ["main", "integration"]
     matching_live["default_branch"] = "integration"
     matching_live["protect_main"] = {
         "id": 1, "required_status_checks": ("test", "build", "base-branch-guard"),
     }
+    matching_live["board_project_id"] = BOARD_PROJECT_ID
+    matching_live["board_status_field_id"] = BOARD_STATUS_FIELD_ID
+    matching_live["board_status_option_ids"] = BOARD_STATUS_OPTION_IDS
+    matching_live["board_repo_items"] = board_repo_items
+    # Item "3" is wrong on purpose, so this live state exercises a set-status action
+    # alongside the already-correct items 1 and 2, rather than yielding zero actions.
+    matching_live["board_items"] = [
+        {"key": "1", "item_id": "PVTI_1", "status": "Accepted"},
+        {"key": "2", "item_id": "PVTI_2", "status": "Deferred"},
+        {"key": "3", "item_id": "PVTI_3", "status": "In progress"},
+    ]
 
     empty_live: dict = {"labels": [], "milestones": [], "issues": [], "rulesets": []}
     empty_live["branches"] = []
     empty_live["default_branch"] = "main"
     empty_live["protect_main"] = {"id": 1, "required_status_checks": ("test", "build")}
+    empty_live["board_project_id"] = BOARD_PROJECT_ID
+    empty_live["board_status_field_id"] = BOARD_STATUS_FIELD_ID
+    empty_live["board_status_option_ids"] = BOARD_STATUS_OPTION_IDS
+    empty_live["board_repo_items"] = board_repo_items
+    empty_live["board_items"] = []
 
     actions = []
     for live in (matching_live, empty_live):
@@ -502,3 +724,35 @@ def test_plan_step_3_6_7_are_represented_among_the_human_steps():
     assert "merge-ready-prs" in HUMAN_STEPS
     assert "retarget-prs" in HUMAN_STEPS
     assert "merge-phase1-pr" in HUMAN_STEPS
+
+
+def test_board_key_distinguishes_repositories_sharing_an_issue_number():
+    """The board is organization-owned, so a bare number is not a unique key on it.
+
+    GitHub numbers issues and pull requests in one sequence per repository, so two
+    repositories in the same organization both have a #92. Keying on the number alone
+    made them collide, and the reconciler would have written the wrong item's column
+    the first time somebody added a second repository's issue to this board, which is
+    the entire reason an organization-level board exists.
+    """
+    from apply_governance import _board_key
+
+    assert _board_key("org/alpha", 92) != _board_key("org/beta", 92)
+    assert _board_key("org/alpha", 92) == _board_key("org/alpha", 92)
+
+
+def test_a_fetch_that_returns_its_own_limit_is_refused():
+    """A truncated fetch reads exactly like a complete one, so it must fail loudly.
+
+    Silently accepting 500 rows when there are 600 makes the missing hundred look
+    absent from the board, so the tool adds duplicates of items already on it and
+    reconciles everything else against a view it cannot see all of.
+    """
+    import pytest
+
+    from apply_governance import FETCH_LIMIT, _reject_truncated
+
+    assert _reject_truncated([1, 2, 3], "short fetch") == [1, 2, 3]
+    with pytest.raises(SystemExit) as caught:
+        _reject_truncated(list(range(FETCH_LIMIT)), "project item-list")
+    assert "truncated" in str(caught.value)

--- a/tools/apply_governance.py
+++ b/tools/apply_governance.py
@@ -20,6 +20,14 @@ or merge someone else's work) or destructive (a deleted label vanishes from ever
 that carried it). No function in this module builds a `gh` argv that merges, closes,
 or edits a pull request, or that deletes a label, and `HUMAN_STEPS` below says so out
 loud when asked for one of the steps that requires a person.
+
+The `board` step reconciles the org-level project board from the same label taxonomy,
+since the board's built-in GitHub workflows add, close, and merge an item but cannot
+move it when a maintainer applies a label, and the label is what the governance turns
+on. It only adds a project item or changes its Status field, never archives or removes
+one, and it runs under a maintainer's own `gh` credentials rather than a token stored
+in the repository, because the board is organization-owned and a workflow's
+`GITHUB_TOKEN` cannot write to it.
 """
 from __future__ import annotations
 
@@ -29,10 +37,16 @@ import shlex
 import subprocess
 import sys
 import tempfile
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
 
 REPO = "GenAI-Security-Project/agent-control-standard"
+
+# The org project board this tool reconciles. Owner is derived from REPO rather than
+# spelled out a second time, since the board and the repository share one org.
+BOARD_OWNER = REPO.split("/", 1)[0]
+BOARD_PROJECT_NUMBER = 9
 
 # The step names this tool will run. Anything else, including every step name in
 # HUMAN_STEPS, is refused rather than guessed at.
@@ -44,6 +58,7 @@ AUTOMATABLE_STEPS = (
     "issues",
     "default-branch",
     "required-check",
+    "board",
 )
 
 # Phase 2 steps this tool deliberately does not run, and why. Keyed by the name someone
@@ -812,6 +827,147 @@ def _protect_main_payload(protect_main: dict) -> dict:
     }
 
 
+# --- Board reconciliation -------------------------------------------------------
+
+# Every column the board step recognizes. "In progress" is never a label rung: it is
+# written either by GitHub's own "Pull request linked to issue" workflow or by this
+# module's own open-pull-request rule, never by a status: label.
+BOARD_STATUSES = ("Done", "Blocked", "In progress", "Accepted", "Deferred", "Needs triage")
+
+_ADD_BOARD_ITEM_MUTATION = (
+    "mutation($project: ID!, $content: ID!) { "
+    "addProjectV2ItemById(input: {projectId: $project, contentId: $content}) "
+    "{ item { id } } }"
+)
+
+_SET_BOARD_STATUS_MUTATION = (
+    "mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) { "
+    "updateProjectV2ItemFieldValue(input: {projectId: $project, itemId: $item, "
+    "fieldId: $field, value: {singleSelectOptionId: $option}}) "
+    "{ projectV2Item { id } } }"
+)
+
+
+def _board_key(repository: object, number: object) -> str:
+    """Build the identity a board item and a repository item are matched on.
+
+    Repository and number together, never the number alone. GitHub numbers issues and
+    pull requests in one sequence per repository, so a number is unique inside a repo
+    and not across the organization-owned board this reconciles.
+    """
+    return f"{repository}#{number}"
+
+
+def desired_board_status(labels: Iterable[str], state: str, is_pull_request: bool) -> str:
+    """Map one issue or pull request to the board status column it belongs in.
+
+    Precedence, highest first, spelled out as a table rather than a chain of ifs a
+    reader has to simulate:
+
+    1. state is CLOSED or MERGED -> Done. State beats every label, so a closed issue
+       carrying status:accepted is done, not accepted.
+    2. status:blocked -> Blocked. A blocked item names what is stuck, which stays
+       true even for a pull request that would otherwise read as merely in flight.
+    3. an open pull request -> In progress. A pull request open at all is work in
+       flight by definition, with or without a label, which is why this rung needs
+       none to fire. It sits below Blocked so a blocked pull request still reads as
+       blocked rather than only in flight.
+    4. status:accepted -> Accepted.
+    5. scope:deferred -> Deferred.
+    6. otherwise -> Needs triage.
+
+    `is_pull_request` is a parameter rather than something sniffed from the labels,
+    because nothing in the label taxonomy records issue versus pull request and
+    guessing from label names would be exactly the kind of implicit rule this
+    function exists to avoid.
+    """
+    label_set = set(labels)
+    if state in ("CLOSED", "MERGED"):
+        return "Done"
+    if "status:blocked" in label_set:
+        return "Blocked"
+    if is_pull_request:
+        return "In progress"
+    if "status:accepted" in label_set:
+        return "Accepted"
+    if "scope:deferred" in label_set:
+        return "Deferred"
+    return "Needs triage"
+
+
+def plan_board_actions(
+    live_items: list[dict],
+    desired_items: list[dict],
+    project_id: str,
+    status_field_id: str,
+    status_option_ids: dict[str, str],
+) -> list[Action]:
+    """Diff the org project board against every issue and pull request in the repo.
+
+    `desired_items` carries every issue and pull request, open or not, keyed by
+    `key`: the issue or pull request number, unique per repository because GitHub
+    issues and pull requests share one numbering sequence. `live_items` carries the
+    same key for whatever is already on the board, with its current column and the
+    project item id a status change would target.
+
+    An item missing from the board is added only while it is open. Backfilling a
+    closed item that was never tracked is history, not governance, so a closed or
+    merged item absent from the board is left alone, per the plan's scope note. An
+    item already on the board is reconciled regardless of open or closed state,
+    which is how a merged pull request that sat in In progress reaches Done.
+
+    An open issue already sitting at In progress is an exception. GitHub's built-in
+    "Pull request linked to issue" workflow puts it there when a pull request links
+    to it, and nothing in the label set records that link. Moving it back to a
+    label-derived column on the next run would fight that workflow every time this
+    tool runs, so an issue found there is left alone rather than relitigated against
+    a decision this function has no way to see the basis for.
+
+    Pure and idempotent: fed live state that already matches every desired item, it
+    returns an empty list.
+    """
+    live_by_key = {entry["key"]: entry for entry in live_items}
+    actions: list[Action] = []
+    for item in desired_items:
+        is_pr = item.get("is_pull_request", False)
+        desired_status = desired_board_status(item.get("labels", ()), item["state"], is_pr)
+        current = live_by_key.get(item["key"])
+
+        if current is None:
+            if item["state"] != "OPEN":
+                continue
+            argv = (
+                "gh", "api", "graphql",
+                "-f", f"query={_ADD_BOARD_ITEM_MUTATION}",
+                "-f", f"project={project_id}",
+                "-f", f"content={item['content_id']}",
+            )
+            actions.append(Action("board", f"Add {item['key']} to the board", argv))
+            continue
+
+        current_status = current.get("status")
+        if current_status == desired_status:
+            continue
+        if not is_pr and item["state"] == "OPEN" and current_status == "In progress":
+            # Sticky In progress for an open issue. See the docstring above: this
+            # column is written by a workflow this function cannot observe, and
+            # overwriting it would fight that workflow on every subsequent run.
+            continue
+
+        argv = (
+            "gh", "api", "graphql",
+            "-f", f"query={_SET_BOARD_STATUS_MUTATION}",
+            "-f", f"project={project_id}",
+            "-f", f"item={current['item_id']}",
+            "-f", f"field={status_field_id}",
+            "-f", f"option={status_option_ids[desired_status]}",
+        )
+        actions.append(
+            Action("board", f"Set {item['key']} status to {desired_status!r}", argv)
+        )
+    return actions
+
+
 def collect_actions(live_state: dict, only: str | None = None) -> list[Action]:
     """Combine every planner, filtered to one step when `only` names one."""
     steps: list[Action] = []
@@ -829,6 +985,14 @@ def collect_actions(live_state: dict, only: str | None = None) -> list[Action]:
         steps += plan_default_branch_actions(live_state)
     if only in (None, "required-check"):
         steps += plan_required_check_actions(live_state)
+    if only in (None, "board"):
+        steps += plan_board_actions(
+            live_state.get("board_items", []),
+            live_state.get("board_repo_items", []),
+            live_state.get("board_project_id", ""),
+            live_state.get("board_status_field_id", ""),
+            live_state.get("board_status_option_ids", {}),
+        )
     return steps
 
 
@@ -863,7 +1027,24 @@ def run_action(action: Action) -> None:
 
 
 def _gh(*args: str) -> str:
-    return subprocess.run(["gh", *args], check=True, capture_output=True, text=True).stdout
+    completed = subprocess.run(["gh", *args], capture_output=True, text=True)
+    if completed.returncode != 0:
+        stderr = (completed.stderr or "").strip()
+        # A maintainer running this by hand gets a readable reason rather than a
+        # traceback. Rate limiting is called out because it is the failure this tool
+        # provokes on its own: a full reconciliation issues one mutation per action,
+        # and a burst of them trips GitHub's secondary limit while the hourly quota
+        # still reads as untouched, which makes the cause non-obvious.
+        if "rate limit" in stderr.lower():
+            raise SystemExit(
+                "GitHub rate limited this run.\n"
+                f"  {stderr}\n"
+                "  A burst of project mutations trips a secondary limit even when the\n"
+                "  hourly quota is full. Wait a few minutes and run again. This tool is\n"
+                "  idempotent, so a partly applied run resumes safely from where it got to."
+            )
+        raise SystemExit(f"gh {' '.join(args)} failed:\n  {stderr}")
+    return completed.stdout
 
 
 def _normalize_ruleset(detail: dict) -> dict:
@@ -884,6 +1065,115 @@ def _normalize_ruleset(detail: dict) -> dict:
         "dismiss_stale_reviews_on_push": pr_params.get("dismiss_stale_reviews_on_push"),
         "require_last_push_approval": pr_params.get("require_last_push_approval"),
         "required_review_thread_resolution": pr_params.get("required_review_thread_resolution"),
+    }
+
+
+FETCH_LIMIT = 500
+
+
+def _reject_truncated(rows: list, what: str) -> list:
+    """Fail when a fetch returned exactly its limit, because that is indistinguishable
+    from a complete result and the caller would treat the missing rows as absent.
+
+    Treating a truncated board as complete is the worst available failure: items past
+    the limit look missing, so the tool adds duplicates of rows already there and
+    reconciles the rest against a board it cannot fully see.
+    """
+    if len(rows) >= FETCH_LIMIT:
+        raise SystemExit(
+            f"{what} returned {len(rows)} rows, the fetch limit. The result is probably "
+            "truncated and reconciling against a partial view would add duplicates. "
+            "Raise FETCH_LIMIT or add pagination before running this again."
+        )
+    return rows
+
+
+def _board_status_field(fields: list[dict]) -> dict:
+    """Find the Status single-select field in a `gh project field-list` response.
+
+    Raises rather than falling back to an empty map, because a missing Status field
+    means every board action this step would render is unsendable. A caller getting
+    an empty option map by default would misreport "nothing to do" instead of
+    failing loudly on a project whose shape changed.
+    """
+    for entry in fields:
+        if entry.get("name") == "Status" and entry.get("type") == "ProjectV2SingleSelectField":
+            return entry
+    raise RuntimeError(f"Project {BOARD_PROJECT_NUMBER} has no single-select Status field")
+
+
+def fetch_board_live_state() -> dict:
+    """Read the org project board and the repo's issues and pull requests via `gh`.
+
+    The project id, the Status field id, and its option ids are all read here, fresh
+    on every run, rather than written into this file. Option ids regenerate whenever
+    a maintainer edits the field's options, which has already happened once in this
+    project's life, so a hardcoded id is a bug waiting on the next edit.
+    """
+    project = json.loads(
+        _gh("project", "view", str(BOARD_PROJECT_NUMBER), "--owner", BOARD_OWNER, "--format", "json")
+    )
+    fields = json.loads(
+        _gh("project", "field-list", str(BOARD_PROJECT_NUMBER), "--owner", BOARD_OWNER, "--format", "json")
+    )["fields"]
+    status_field = _board_status_field(fields)
+    status_option_ids = {option["name"]: option["id"] for option in status_field["options"]}
+
+    raw_board_items = json.loads(
+        _gh(
+            "project", "item-list", str(BOARD_PROJECT_NUMBER), "--owner", BOARD_OWNER,
+            "--format", "json", "--limit", str(FETCH_LIMIT),
+        )
+    )["items"]
+    _reject_truncated(raw_board_items, "project item-list")
+    board_items = [
+        {
+            # Keyed by repository and number together. The board is organization-owned
+            # and may hold items from any repository in the org, so a bare number is
+            # not unique on it: another repo's #92 would collide with this one's and
+            # the reconciler would write the wrong item's column.
+            "key": _board_key(entry["content"].get("repository"), entry["content"]["number"]),
+            "item_id": entry["id"],
+            "status": entry["status"],
+        }
+        for entry in raw_board_items
+        # A draft issue item has no content.number. It carries no repository issue or
+        # pull request to reconcile against, so it is outside this step's scope.
+        if "number" in entry.get("content", {})
+    ]
+
+    raw_issues = json.loads(
+        _gh(
+            "issue", "list", "--repo", REPO, "--state", "all", "--limit", str(FETCH_LIMIT),
+            "--json", "id,number,labels,state",
+        )
+    )
+    raw_prs = json.loads(
+        _gh(
+            "pr", "list", "--repo", REPO, "--state", "all", "--limit", str(FETCH_LIMIT),
+            "--json", "id,number,labels,state",
+        )
+    )
+    _reject_truncated(raw_issues, "issue list")
+    _reject_truncated(raw_prs, "pr list")
+    repo_items = [
+        {
+            "key": _board_key(REPO, entry["number"]),
+            "content_id": entry["id"],
+            "labels": [label["name"] for label in entry["labels"]],
+            "state": entry["state"],
+            "is_pull_request": is_pull_request,
+        }
+        for is_pull_request, batch in ((False, raw_issues), (True, raw_prs))
+        for entry in batch
+    ]
+
+    return {
+        "board_project_id": project["id"],
+        "board_status_field_id": status_field["id"],
+        "board_status_option_ids": status_option_ids,
+        "board_items": board_items,
+        "board_repo_items": repo_items,
     }
 
 
@@ -908,7 +1198,7 @@ def fetch_live_state() -> dict:
     ]
 
     raw_issues = json.loads(
-        _gh("issue", "list", "--state", "all", "--limit", "500", "--json", "title,body,labels")
+        _gh("issue", "list", "--state", "all", "--limit", str(FETCH_LIMIT), "--json", "title,body,labels")
     )
     issues = [
         {"title": entry["title"], "body": entry.get("body") or "",
@@ -927,6 +1217,7 @@ def fetch_live_state() -> dict:
 
     branches = json.loads(_gh("api", f"repos/{REPO}/branches", "--paginate", "--jq", "[.[].name]"))
     repo_info = json.loads(_gh("api", f"repos/{REPO}"))
+    board = fetch_board_live_state()
 
     return {
         "labels": labels,
@@ -936,6 +1227,11 @@ def fetch_live_state() -> dict:
         "branches": branches,
         "default_branch": repo_info.get("default_branch"),
         "protect_main": details.get("protect-main"),
+        "board_project_id": board["board_project_id"],
+        "board_status_field_id": board["board_status_field_id"],
+        "board_status_option_ids": board["board_status_option_ids"],
+        "board_items": board["board_items"],
+        "board_repo_items": board["board_repo_items"],
     }
 
 
@@ -946,8 +1242,9 @@ def build_parser() -> argparse.ArgumentParser:
         prog="apply_governance.py",
         description=(
             "Apply Phase 2 of the contribution-governance plan: labels, milestones, "
-            "issues, and the integration and release rulesets. Prints the gh and git "
-            "commands it would run by default. Pass --apply to run them."
+            "issues, the integration and release rulesets, and the org project board. "
+            "Prints the gh and git commands it would run by default. Pass --apply to "
+            "run them."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
## What

Three paragraphs added to `docs/spec/conformance.md`, directly after the "What \"ACS-Core conformant\" guarantees" paragraph:

1. A plain statement that conformance at any tier is a technical measure — it cannot attest that the system producing it is connected to human intent, and stronger conformance evidence raises rather than lowers the risk of it being accepted as a substitute for institutional accountability.
2. A concrete crosswalk naming the governance requirements (NIST AI RMF GOVERN, MAESTRO L7, OWASP LLM06:2025) that conformance therefore does not satisfy.
3. Two sentences on how the out-of-scope claims can be verified external to ACS — a publicly authorized bootstrap and Approver-to-human delegation chains — with ACS-Trace/ACS-Audit positioned as the right tools to record them where they exist.

No wire-format changes, no new profiles, no new conformance requirements.

## Why

The conformance doc already says what ACS-Core does and doesn't guarantee technically. It doesn't yet address the gap between a record being *structurally* valid and the event it describes being *substantively* real. That gap matters because ACS produces exactly the artifacts governance reviews look for — decisions, audit chains, verified Approver identities — and a fully conformant deployment can produce all of them with no human anywhere in the loop: policy authored by automation, every ASK decision answered by an automated service, audit chain complete and intact. Nothing on the wire distinguishes that deployment from a human-governed one.

The closing sentence states the uncomfortable corollary: the risk scales with conformance quality. The stronger the evidence, the more readily it gets accepted as a substitute for the institutional accountability it cannot attest. Without scope language in the spec, conformance will be cited as governance evidence — the spec deserves to say plainly that it is not, absent commensurate evidence that the governance itself is authored, adopted, and run by a human with the authority to do so.

## Relationship to existing work

- PR #9's identity workstream (Challenge #5, Proof of Intent) already identifies human-approved Intent extension as a requirement. This paragraph is the complement: it describes the current state honestly while that mechanism gap is worked.
- Against NIST AI RMF: ACS provides MAP/MEASURE capabilities but has no surface for the GOVERN function; the crosswalk paragraph keeps adopters from reading one in.
- Purely additive to `conformance.md`; does not conflict with #21's slimming changes.

This is protective language for the standard, not a critique of it — a spec that names its limits is one whose guarantees can be trusted.

Closes #136.
