### PR TITLE
Harden repository security posture and CI supply chain

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,28 @@
+# Code owners for the Agent Control Standard.
+#
+# Owners listed here are required reviewers on the paths they own, enforced by
+# the ruleset on main. Everyone below has write access, which GitHub requires
+# for CODEOWNERS entries to take effect.
+#
+# Keep this file in sync with repository collaborator roles. A handle that
+# loses write access stops being a valid owner and GitHub fails the entry
+# silently.
+
+# Default owners for anything not matched below.
+*                       @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @stefanoamorelli @almogbhl @bar-capsule
+
+# The specification is the highest-blast-radius surface in the repository.
+# A schema change propagates to every downstream implementer.
+/specification/         @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @stefanoamorelli @almogbhl @bar-capsule
+/docs/spec/             @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @stefanoamorelli @almogbhl @bar-capsule
+
+# CI runs with write access to the repository. Changes here are a
+# privilege-escalation surface and warrant admin review.
+/.github/               @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp
+
+# Licensing and security policy changes are governance decisions.
+/LICENSE                @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp
+/LICENSE-DOCS           @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp
+/LICENSING.md           @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp
+/NOTICE                 @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp
+/SECURITY.md            @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,16 @@
+# Routes people away from filing security reports as public issues, which is
+# the single most common way a coordinated disclosure gets blown.
+
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/GenAI-Security-Project/agent-control-standard/security/advisories/new
+    about: Do not open a public issue. Report privately here. See SECURITY.md for scope, response times, and safe harbor.
+
+  - name: Propose a specification change
+    url: https://github.com/GenAI-Security-Project/agent-control-standard/discussions
+    about: Schema, hook, and event changes affect every downstream implementer. Start a Discussion before opening a PR.
+
+  - name: Ask a question
+    url: https://github.com/GenAI-Security-Project/agent-control-standard/discussions
+    about: Questions about using or implementing ACS belong in Discussions.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,56 @@
+# Dependabot version updates.
+#
+# Security updates are enabled separately in repository settings and fire on
+# advisories regardless of this file. This config covers routine version
+# drift, so a dependency is current before it becomes a CVE.
+#
+# Every ecosystem sets a cooldown. A compromised release is most dangerous in
+# the hours after publication, and registry takeovers are usually caught and
+# yanked within days. Waiting before proposing a bump costs nothing here and
+# keeps a poisoned version from landing in a PR that looks routine.
+
+version: 2
+updates:
+  # GitHub Actions run with write access to the repository. Actions are pinned
+  # to commit SHAs in the workflows, and Dependabot understands SHA pins and
+  # updates them along with the version comment.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  # Python dependencies resolved through uv.lock. The only runtime surface is
+  # the documentation build and the version-sync script.
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    labels:
+      - "dependencies"
+      - "python"
+    groups:
+      # Patch and minor bumps for the docs toolchain land as one PR. Majors
+      # stay separate, since mkdocs-material majors have broken builds before.
+      docs-toolchain:
+        patterns:
+          - "mkdocs*"
+          - "mike"
+          - "pymdown-extensions"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+## What changed
+
+<!-- One or two sentences. What does this PR do and why? -->
+
+## Type of change
+
+- [ ] Specification change (schema, hooks, events, AgBOM)
+- [ ] Documentation
+- [ ] Tooling or CI
+- [ ] Governance (licensing, security policy, contributor docs)
+
+## Specification changes
+
+<!-- Delete this section if you touched nothing under specification/ or docs/spec/. -->
+
+- [ ] I opened a [Discussion](https://github.com/GenAI-Security-Project/agent-control-standard/discussions) before this PR
+- [ ] Schema changes validate against the JSON Schema spec
+- [ ] I described the impact on downstream implementers below
+
+**Breaking for implementers?** <!-- yes or no, and what breaks -->
+
+## Checklist
+
+- [ ] Commits are signed off with `git commit -s` (required by the DCO)
+- [ ] Prose follows [STYLE.md](../STYLE.md)
+- [ ] `uv run mkdocs build --strict` passes
+- [ ] No secrets, tokens, or internal URLs in the diff
+
+## Security
+
+- [ ] This change has no security impact
+
+<!-- If it does, describe it. Do not open a PR for an unreported vulnerability.
+     Report it privately first: see SECURITY.md. -->

--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -1,0 +1,16 @@
+# Paths excluded from GitHub secret scanning.
+#
+# The A2A hook documentation contains signed agent-card examples. Those JWTs
+# illustrate the JWS structure that the specification requires. They are not
+# credentials, they authenticate nothing, and their payloads decode to sample
+# agent metadata such as {"name": "Content generator", "provider": ...}.
+#
+# Without this exclusion, secret scanning flags twelve of them and push
+# protection blocks anyone editing the A2A specification. Contributors then
+# learn to click through the warning, which is worse than having no push
+# protection at all.
+#
+# Scope this narrowly. Do not add paths that hold real configuration.
+
+paths-ignore:
+  - "docs/spec/instrument/a2a/hooks/**"

--- a/.github/workflows/sync_version.yml
+++ b/.github/workflows/sync_version.yml
@@ -1,82 +1,94 @@
-# This workflow synchronizes the version from the version.txt file to all project files
-# It can be triggered manually or on changes to the version.txt file
+# Synchronizes the version in version.txt across the project files.
+# Triggers on a push to version.txt on main, or manually.
 name: Sync Version
 
 on:
-  # Trigger on changes to version.txt file
   push:
     paths:
       - 'version.txt'
     branches: ["main"]
-  
-  # Allow manual trigger
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+# Deny by default. The one job below grants itself only what it needs.
+permissions: {}
+
+# A second push to version.txt while a run is in flight would race the first
+# on the same branch name.
+concurrency:
+  group: sync-version-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   sync-version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write        # create the version-sync branch
+      pull-requests: write   # open the PR
     steps:
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-      
+      - name: Check out the repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
         with:
-          version: "latest"
-      
-      - name: Configure Git
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-      
-      - name: Read version from version.txt file
+          version: "0.9.9"
+
+      - name: Read and validate version
         id: version
         run: |
-          VERSION=$(cat version.txt)
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Current version: $VERSION"
-      
+          set -euo pipefail
+          VERSION="$(tr -d '[:space:]' < version.txt)"
+          # version.txt is attacker-controlled by anyone with write access.
+          # Anything not matching semver stops here rather than reaching a
+          # shell, a git ref, or PR body markdown downstream.
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$'; then
+            echo "::error file=version.txt::Not a valid semantic version"
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Validated version: ${VERSION}"
+
       - name: Sync versions across files
+        env:
+          # Passed through the environment, never interpolated into the shell
+          # command. A ${{ }} expansion inside run: would execute as code.
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          uv run .github/workflows/sync_version.py "${{ env.VERSION }}"
-      
+          set -euo pipefail
+          uv run .github/workflows/sync_version.py "$VERSION"
+
       - name: Check for changes
         id: changes
         run: |
+          set -euo pipefail
           if git diff --quiet; then
-            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
             echo "No changes detected"
           else
-            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
             echo "Changes detected"
           fi
-      
-      - name: Create Pull Request
+
+      - name: Create pull request
         if: steps.changes.outputs.has_changes == 'true'
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "Automated: sync version to ${{ env.VERSION }}"
-          title: "Sync version to ${{ env.VERSION }}"
+          commit-message: "Automated: sync version to ${{ steps.version.outputs.version }}"
+          title: "Sync version to ${{ steps.version.outputs.version }}"
           body: |
-            This PR synchronizes the version across all project files to `${{ env.VERSION }}`.
-            
+            Synchronizes the version across project files to `${{ steps.version.outputs.version }}`.
+
             Updated files:
             - `pyproject.toml`
             - `docs/spec/instrument/specification.md`
             - `specification/ACS/acs_schema.json`
-            
-            The version was read from the `version.txt` file.
-          branch: version-sync-${{ env.VERSION }}
+
+            The version was read from `version.txt` and validated as semver.
+          branch: version-sync-${{ steps.version.outputs.version }}
           delete-branch: true
+          sign-commits: true
           add-paths: |
             pyproject.toml
             docs/spec/instrument/specification.md
             specification/ACS/acs_schema.json
-          

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,27 @@
+# Gitleaks allowlist.
+#
+# Every entry below is a signed agent-card example in the A2A hook
+# documentation. The specification requires a JWS structure, so the examples
+# have to show a real-shaped JWT. These authenticate nothing. Payloads decode
+# to sample metadata such as:
+#   {"name": "Content generator", "provider": {"name": "OpenAI", ...}}
+#
+# Verified 2026-08-11 across all 250 commits: 12 findings, all from commit
+# d24eab0, all rule "jwt", all documentation. No real credentials in history.
+#
+# Add an entry only after decoding the token and confirming it is an example.
+# A fingerprint is commit:path:rule:line, so an entry stops matching if the
+# content moves. That is intentional. Moved content gets re-reviewed.
+
+d24eab0343460c27d9622910250b027b80fca9bd:docs/spec/instrument/a2a/hooks/cancel_task_request.md:jwt:64
+d24eab0343460c27d9622910250b027b80fca9bd:docs/spec/instrument/a2a/hooks/cancel_task_request.md:jwt:151
+d24eab0343460c27d9622910250b027b80fca9bd:docs/spec/instrument/a2a/hooks/get_task_push_notification_config_request.md:jwt:63
+d24eab0343460c27d9622910250b027b80fca9bd:docs/spec/instrument/a2a/hooks/get_task_push_notification_config_request.md:jwt:149
+d24eab0343460c27d9622910250b027b80fca9bd:docs/spec/instrument/a2a/hooks/get_task_request.md:jwt:68
+d24eab0343460c27d9622910250b027b80fca9bd:docs/spec/instrument/a2a/hooks/get_task_request.md:jwt:159
+d24eab0343460c27d9622910250b027b80fca9bd:docs/spec/instrument/a2a/hooks/resubscribe_to_task_request.md:jwt:64
+d24eab0343460c27d9622910250b027b80fca9bd:docs/spec/instrument/a2a/hooks/resubscribe_to_task_request.md:jwt:151
+d24eab0343460c27d9622910250b027b80fca9bd:docs/spec/instrument/a2a/hooks/set_task_push_notification_config_request.md:jwt:71
+d24eab0343460c27d9622910250b027b80fca9bd:docs/spec/instrument/a2a/hooks/set_task_push_notification_config_request.md:jwt:165
+d24eab0343460c27d9622910250b027b80fca9bd:docs/spec/instrument/a2a/hooks/stream_message_request.md:jwt:110
+d24eab0343460c27d9622910250b027b80fca9bd:docs/spec/instrument/a2a/hooks/stream_message_request.md:jwt:243

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,66 @@
+# Security Policy
+
+ACS is a specification. Most of what lives here is prose and JSON Schema, so the security surface is narrower than a typical software project. Report anything you find anyway. A flaw in the specification propagates into every implementation that follows it.
+
+## Report a vulnerability
+
+**Do not open a public issue.**
+
+Use GitHub's [private vulnerability reporting](https://github.com/GenAI-Security-Project/agent-control-standard/security/advisories/new). Reports land with the maintainers and stay private until we publish an advisory together.
+
+Include what you have:
+
+- What you found and where, with a file path or a link to the specific line
+- How to reproduce it, or the reasoning chain if the flaw is in the specification rather than in code
+- What an attacker gains
+- Any suggested fix
+
+Partial reports are welcome. We would rather triage something incomplete than never hear about it.
+
+## What is in scope
+
+| In scope | Out of scope |
+| --- | --- |
+| Flaws in the ACS specification that lead implementers into insecure designs | The documentation site at agentcontrolstandard.ai, which is built from a separate repository |
+| Errors in the JSON Schemas under `specification/` | Findings against third-party agent frameworks that happen to implement ACS |
+| The GitHub Actions workflows in `.github/workflows/` | Automated scanner output with no demonstrated impact |
+| Hook or event definitions that leak sensitive data by design | Missing security headers on sites we do not operate |
+| Supply-chain issues in this repository's dependencies | Social engineering of maintainers or contributors |
+
+A specification flaw counts. If a hook definition forces implementers to log secrets, or an event schema makes an authorization bypass easy to write, that is a finding even though no code here executes.
+
+## Response commitments
+
+| Stage | Target |
+| --- | --- |
+| Acknowledge your report | 3 business days |
+| Initial triage and severity assessment | 10 business days |
+| Fix or documented mitigation for high and critical findings | 90 days from triage |
+| Public advisory | Coordinated with you, at or before day 90 |
+
+We use [CVSS v3.1](https://www.first.org/cvss/calculator/3.1) for severity. Specification flaws get scored against a reference implementation, since the specification itself has no runtime.
+
+## Coordinated disclosure
+
+We publish an advisory once a fix ships, or at 90 days from triage, whichever comes first. If a fix needs longer, we tell you why and agree a new date rather than letting the clock run out quietly.
+
+Tell us how you want to be credited, including if you prefer not to be. We credit reporters in the advisory by default.
+
+If you believe a finding is being actively exploited, say so in the report. That moves it to the front of the queue and shortens every window above.
+
+## Safe harbor
+
+We will not pursue or support legal action against research conducted under this policy, provided you:
+
+- Report through the private channel above and give us a chance to fix the issue before disclosing it
+- Avoid privacy violations, data destruction, and interruption of any service
+- Access only the minimum data needed to demonstrate the finding, and delete it once you have reported
+- Do not exploit a finding beyond what proving it requires
+
+Work in good faith under these terms and we treat your research as authorized. If a third party brings action against you for research that followed this policy, we will make that authorization clear.
+
+## Signing and provenance
+
+Contributors sign off commits under the Developer Certificate of Origin. See [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+Report suspected compromise of a maintainer account or a release artifact through the private channel above, marked urgent.


### PR DESCRIPTION
Adds the governance and security files a public standards repository is expected to carry, and closes two live weaknesses in the version-sync workflow.

Merge this **before** secret scanning and push protection get enabled, so the allowlists are in place first.

## Security policy

`SECURITY.md` publishes a VDP with scope, response SLAs, a coordinated-disclosure timeline, and safe-harbor language. Private vulnerability reporting was already enabled on the repo, but nothing pointed researchers at it.

`.github/ISSUE_TEMPLATE/config.yml` routes security reports to the advisory form instead of public issues, which is the most common way a coordinated disclosure gets blown.

## Review gates

`.github/CODEOWNERS` requires review from the 9 admins and maintainers, with `specification/`, `docs/spec/`, `.github/`, and the licensing files called out separately. All nine handles were verified to hold write access, since GitHub fails invalid CODEOWNERS entries silently.

## Dependency hygiene

`.github/dependabot.yml` adds version updates for `github-actions` and `uv`, each with a **7-day cooldown**. A compromised release is most dangerous in the hours after publication, and registry takeovers are usually caught and yanked within days.

## Workflow hardening

`sync_version.yml` had two real problems.

**Unpinned actions.** All three were mutable tags, so a compromised tag would execute with `contents: write`. Now pinned to commit SHAs. All three were also majors behind:

| Action | Was | Now |
| --- | --- | --- |
| `actions/checkout` | v4 | v7.0.1 |
| `astral-sh/setup-uv` | v4 | v9.0.0 |
| `peter-evans/create-pull-request` | v5 | v8.1.1 |

`uv` was `version: "latest"`, resolved fresh at run time. Now pinned to `0.9.9`.

**Script injection.** The old line 47 interpolated the contents of `version.txt` directly into a shell command:

```yaml
run: uv run .github/workflows/sync_version.py "${{ env.VERSION }}"
```

Chained with an unprotected `main`, anyone with write access could push a crafted `version.txt`, fire the push trigger, and run their payload in CI holding a write-scoped token. The value is now validated against a semver pattern and passed through `env:` rather than expanded into the shell.

Also: `permissions: {}` at workflow level with grants scoped to the one job that needs them, a concurrency group, and `sign-commits: true` on generated PRs.

## Secret-scanning allowlists

`.github/secret_scanning.yml` and `.gitleaksignore` cover the signed agent-card examples in the A2A hook docs.

A full history scan across **250 commits found 12 findings, all false positives** — all from commit `d24eab0`, all rule `jwt`, all documentation. I decoded one to confirm: the payload is `{"name": "Content generator", "provider": {"name": "OpenAI", ...}}`, an illustrative agent card with `kid: agent-key-12345`. **No real credentials in history.**

The allowlists matter operationally. Without them, push protection blocks anyone editing the A2A specification, and contributors learn to click through the warning, which is worse than having no push protection.

## Verification

- All new YAML parses
- `gitleaks detect` over full history: **12 findings → 0** with the allowlist
- All 9 CODEOWNERS handles confirmed at write or above
- `uv run mkdocs build --strict` passes

## Applied separately as repo settings

Ruleset on `main` (PR required, 1 approval, CODEOWNER review, no force-push, no deletion, admin bypass), Actions default token to read-only, SHA pinning required, and secret scanning with push protection.

## Not addressed here

The 15 Dependabot alerts on `main`, and fork detachment from `OWASP/www-project-agent-observability-standard`, which needs GitHub Support.