### PR TITLE
Add conformance/negative/: vectors, failure codes, and runner (closes the suite gap for the enforcement layer)

### DIFF
--- a/conformance/negative/README.md
+++ b/conformance/negative/README.md
@@ -105,6 +105,35 @@ count it would otherwise print - `0/0 vectors conform` with a zero exit - is
 indistinguishable from a suite that passed. The rule the structural gate applies per
 category applies to the suite itself.
 
+## Negative controls for the suite itself
+
+```
+python conformance/negative/selftest.py
+```
+
+A suite that has only ever been run against an implementation which passes it has not been
+shown to discriminate, and a verifier that rejected every input would pass every must-reject
+vector ever written. `selftest.py` is the pairing: twenty-four cases the suite must refuse,
+plus the one it must accept, so that a green run means the gate is live rather than absent.
+
+Three families. **Fake adapters** enforce nothing or satisfy the letter of the adapter
+contract while defeating its purpose: one that would read the answer key, one that refuses
+everything, one that allows everything, one that names no entry point, one whose entry point
+is only whitespace, one that answers the must-pass inputs from a second path, and two that
+return the right verdict with the wrong code or the wrong reason. **Runner guards** are
+inputs refused before any adapter is consulted: an empty suite, and a suite whose positive
+controls have been removed. **Adapter mutants** delete exactly one check from the reference
+adapter, one mutant per check, and the suite has to go red for every one.
+
+The mutants are the part that finds vectors nobody wrote. A mutant that survives is not a
+tolerable gap: it names a rule the suite claims to enforce and does not exercise. Two came
+out of the first run of this file. The entry-point check accepted a name made of spaces,
+because `if not ep` is true for `""` and false for `"   "`. And the rule refusing an action
+whose signing device was never read survived its own deletion, because no vector exercised
+it - `neg-cat4-003` is that vector, and it was written because the mutant lived. A mutant
+whose pattern no longer matches the adapter is reported as such rather than counted as
+killed, so a rule that silently stops being tested shows up as a changed count.
+
 ## Provenance
 
 Vectors are generalized from an enforcement layer running in production since June 2026

--- a/conformance/negative/README.md
+++ b/conformance/negative/README.md
@@ -1,0 +1,86 @@
+# Negative conformance vectors for the enforcement layer
+
+Implements the proposal of issue #29 and the conformance-suite gap of issue #19.
+
+The security value of an enforcement point is defined by its behaviour on inputs that are
+*almost* right. This directory holds test vectors for those inputs: actions that are correctly
+signed but unauthorized, replayed, stale, bound to the wrong principal, carried by malformed
+evidence, or stripped of their observability references.
+
+## Design rules
+
+**1. Two rejection verdicts, never one.** A rejection because evidence was measured and found
+wrong (`REJECT`) is a different verdict from a rejection because evidence could not be measured
+at all (`UNMEASURABLE`). Both must refuse the action. Collapsing them either lets unmeasurable
+inputs fail open, or sends operators hunting for frauds that never happened. Every vector
+declares which of the two it expects.
+
+**2. Every category carries a positive control.** Each category includes at least one
+almost-identical input that MUST pass. A suite made only of must-reject inputs cannot
+distinguish an enforcement layer that works from one that rejects everything. The runner fails
+the whole suite if any category lacks its positive control.
+
+**3. Vectors are framework-agnostic.** A vector describes an action, its authorization
+evidence, and the state the enforcement point can consult. It never references a specific
+implementation. Each implementation provides one adapter (see `runner.py`).
+
+**4. Declared gaps are part of the suite.** Category 3 (expired or revoked mandates) is
+covered here for expiry only. Revocation vectors are absent because the contributing
+implementation has no revocation mechanism, by documented decision, and vectors for a path
+never exercised in production would be design fiction. The gap is stated rather than filled.
+Contributions from implementations that exercise revocation are the way to close it.
+
+## Failure codes (proposed enumeration)
+
+| Code | Verdict | Meaning |
+|---|---|---|
+| `CONTEXT_NOT_SUPPORTED` | REJECT | Signature valid, but the consulted state does not carry this action (wrong target, closed auction, exceeded bound) |
+| `REPLAY_CONSUMED` | REJECT | The authorization was already used once; one authorization covers one act |
+| `STALE_DECISION` | REJECT | The evidence is older than the declared freshness bound |
+| `PRINCIPAL_MISMATCH` | REJECT | Approval bound to a different agent, tool, or signing device than the one acting |
+| `REFERENCE_MISSING` | REJECT | A required observability reference is absent or zeroed |
+| `REFERENCE_MISMATCH` | REJECT | The named reference diverges from the one already bound to this action's context |
+| `MALFORMED_EVIDENCE` | UNMEASURABLE | Evidence present but not decodable to the declared shape; consumers must fail closed |
+| `ORACLE_UNAVAILABLE` | UNMEASURABLE | The state needed to judge could not be read; absence of measurement is never a pass |
+
+## Vector schema
+
+```json
+{
+  "id": "neg-cat1-001",
+  "category": 1,
+  "description": "what makes this input almost right, and why it must fail",
+  "input": {
+    "action": { },
+    "authorization": { },
+    "state": { }
+  },
+  "expected": {
+    "verdict": "REJECT | UNMEASURABLE | PASS",
+    "code": "one of the enumeration above, absent for PASS",
+    "reason_must_mention": ["substring the refusal message must contain"]
+  },
+  "positive_control": false
+}
+```
+
+`reason_must_mention` exists because a correct verdict with a wrong reason is a latent bug:
+an enforcement point can reject for the wrong cause and pass the suite while hunting the
+wrong class of attack.
+
+## Running
+
+```
+python conformance/negative/runner.py --adapter your_adapter.py
+```
+
+The adapter exposes `evaluate(vector) -> {"verdict": ..., "code": ..., "reason": ...}`.
+The runner exits non-zero on: any verdict mismatch, any code mismatch, any missing
+`reason_must_mention` substring, or any category lacking a positive control.
+
+## Provenance
+
+Vectors are generalized from an enforcement layer running in production since June 2026
+(hash-chained decision registries, out-of-band human confirmation, on-chain context checks).
+Each rejection code in the enumeration was produced by a real refusal before it was named
+here. The field notes behind them are public: https://github.com/avp9-nexus/nexus-art

--- a/conformance/negative/README.md
+++ b/conformance/negative/README.md
@@ -38,7 +38,7 @@ Contributions from implementations that exercise revocation are the way to close
 | `REPLAY_CONSUMED` | REJECT | The authorization was already used once; one authorization covers one act |
 | `STALE_DECISION` | REJECT | The evidence is older than the declared freshness bound |
 | `PRINCIPAL_MISMATCH` | REJECT | Approval bound to a different agent, tool, or signing device than the one acting |
-| `REFERENCE_MISSING` | REJECT | A required observability reference is absent or zeroed |
+| `REFERENCE_MISSING` | REJECT | A required observability reference is present and unusable: zeroed, or bound to a different context |
 | `REFERENCE_MISMATCH` | REJECT | The named reference diverges from the one already bound to this action's context |
 | `MALFORMED_EVIDENCE` | UNMEASURABLE | Evidence present but not decodable to the declared shape; consumers must fail closed |
 | `ORACLE_UNAVAILABLE` | UNMEASURABLE | The state needed to judge could not be read; absence of measurement is never a pass |
@@ -77,15 +77,33 @@ wrong class of attack.
 python conformance/negative/runner.py --adapter your_adapter.py
 ```
 
-The adapter exposes `evaluate(vector) -> {"verdict": ..., "code": ..., "reason": ...,
-"entry_point": ...}`, where `entry_point` names the production entry point the adapter
-dispatched through for that vector. The runner exits non-zero on: any verdict mismatch,
-any code mismatch (positive controls included), any missing `reason_must_mention`
-substring, any category lacking a positive control (a control counts only if it expects
-`PASS`), any answer naming no entry point, or any category whose positive controls
-resolved through a different entry point than its negative vectors. The last two rules
-exist because a suite whose positive controls certify a test double certifies nothing:
-an adapter that reads the answer key passes every content check and fails only there.
+The adapter exposes `evaluate(question) -> {"verdict": ..., "code": ..., "reason": ...,
+"entry_point": ...}`, where `question` carries only `{"id", "category", "input"}` - the
+expected verdict and the `positive_control` flag never leave the runner - and `entry_point`
+names the production entry point the adapter dispatched through for that vector. The runner
+exits non-zero on: an empty suite, any verdict mismatch, any code mismatch (positive
+controls included), any missing `reason_must_mention` substring, any category lacking a
+positive control (a control counts only if it expects `PASS`), any answer naming no entry
+point, or any category whose positive controls resolved through a different entry point
+than its negative vectors. Vector failures and category failures are counted and reported
+separately, so the conformance count never absorbs a category-level result.
+
+The answer key is handled one layer earlier: since the adapter is never handed the expected
+verdict, an adapter that would derive its answer from it has nothing to derive it from, and
+fails on its first call. That family is no longer something the suite detects, it is
+something that cannot be expressed (review of 2026-08-27, run against `459ec820`: a
+six-line answer-key adapter scored 18/18 under the previous contract, and scores 0/18 with
+`KeyError: 'expected'` under this one).
+
+The entry-point rules remain a declaration the runner compares only against itself. They
+catch a suite whose positive controls and negative vectors resolve through different paths;
+they do not establish that the named function ran. Observing execution from outside the
+adapter is the mechanism that would, and it is discussed in #35.
+
+An empty vector file is refused. A suite with no vectors distinguishes nothing, and the
+count it would otherwise print - `0/0 vectors conform` with a zero exit - is
+indistinguishable from a suite that passed. The rule the structural gate applies per
+category applies to the suite itself.
 
 ## Provenance
 

--- a/conformance/negative/README.md
+++ b/conformance/negative/README.md
@@ -45,6 +45,9 @@ Contributions from implementations that exercise revocation are the way to close
 
 ## Vector schema
 
+All eighteen vectors live as a single array in `vectors/negative_vectors.json`; the schema
+below describes one entry.
+
 ```json
 {
   "id": "neg-cat1-001",
@@ -74,9 +77,15 @@ wrong class of attack.
 python conformance/negative/runner.py --adapter your_adapter.py
 ```
 
-The adapter exposes `evaluate(vector) -> {"verdict": ..., "code": ..., "reason": ...}`.
-The runner exits non-zero on: any verdict mismatch, any code mismatch, any missing
-`reason_must_mention` substring, or any category lacking a positive control.
+The adapter exposes `evaluate(vector) -> {"verdict": ..., "code": ..., "reason": ...,
+"entry_point": ...}`, where `entry_point` names the production entry point the adapter
+dispatched through for that vector. The runner exits non-zero on: any verdict mismatch,
+any code mismatch (positive controls included), any missing `reason_must_mention`
+substring, any category lacking a positive control (a control counts only if it expects
+`PASS`), any answer naming no entry point, or any category whose positive controls
+resolved through a different entry point than its negative vectors. The last two rules
+exist because a suite whose positive controls certify a test double certifies nothing:
+an adapter that reads the answer key passes every content check and fails only there.
 
 ## Provenance
 

--- a/conformance/negative/reference_adapter.py
+++ b/conformance/negative/reference_adapter.py
@@ -26,7 +26,13 @@ def evaluate(vector):
         if oracle.get("shape", "").endswith("_6_fields") and oracle.get("fields_served") != 6:
             return unmeasurable("MALFORMED_EVIDENCE", f"expected 6 fields, served {oracle.get('fields_served')}")
 
-    # Observability references: the omission itself is refused, before anything else.
+    # Observability references. NOTE: this can only judge a reference that is present and
+    # wrong. Nothing in a vector declares that a given action REQUIRED one, so an action
+    # that omits the field is indistinguishable here from one for which no reference was
+    # ever due - `commit_funds` appears in this suite both with a reference (category 6)
+    # and without one on vectors that must pass. The "absent" arm of REFERENCE_MISSING is
+    # therefore not expressible against the current vector shape, and the enumeration text
+    # says so rather than promising it.
     if "registry_ref" in action:
         ref = action["registry_ref"]
         if set(ref.replace("0x", "")) == {"0"}:
@@ -39,8 +45,17 @@ def evaluate(vector):
     # Principal binding.
     if auth.get("decision_for") and auth["decision_for"] != action.get("actor"):
         return reject("PRINCIPAL_MISMATCH", f"decision names agent {auth['decision_for']}, actor differs")
-    if "required_signer" in action and auth.get("connected_device_derives") not in (None, action["required_signer"]):
-        return reject("PRINCIPAL_MISMATCH", "connected device derives a different key; wrong device")
+    if "required_signer" in action:
+        # `not in (None, required)` accepted the absence of evidence: an action naming a
+        # required signer, with nothing said about the connected device, passed every guard.
+        # Absence of a measurement is never a match; it is the UNMEASURABLE case by the
+        # enumeration's own distinction.
+        derived = auth.get("connected_device_derives")
+        if derived is None:
+            return unmeasurable("ORACLE_UNAVAILABLE",
+                                "no evidence of which device is connected; absence is never a match")
+        if derived != action["required_signer"]:
+            return reject("PRINCIPAL_MISMATCH", "connected device derives a different key; wrong device")
 
     # Replay.
     if auth.get("consumed"):

--- a/conformance/negative/reference_adapter.py
+++ b/conformance/negative/reference_adapter.py
@@ -1,0 +1,67 @@
+"""Reference adapter: a minimal enforcement layer that satisfies the negative suite.
+
+Ships WITH the suite for one reason: a runner nobody can execute end-to-end is a promise.
+This adapter is the suite's own positive control. It is deliberately small and readable;
+it is not a product.
+"""
+
+
+def evaluate(vector):
+    inp = vector["input"]
+    action, auth, state = inp.get("action", {}), inp.get("authorization", {}), inp.get("state", {})
+
+    def reject(code, reason):
+        return {"verdict": "REJECT", "code": code, "reason": reason}
+
+    def unmeasurable(code, reason):
+        return {"verdict": "UNMEASURABLE", "code": code, "reason": reason}
+
+    # Evidence shape first: fail closed on what cannot be decoded, with its own code.
+    oracle = state.get("oracle_response", "ABSENT_KEY")
+    if oracle is None:
+        return unmeasurable("ORACLE_UNAVAILABLE", "state could not be measured; absence is never a pass")
+    if isinstance(oracle, dict):
+        if oracle.get("shape") == "address" and not oracle.get("bytes_hex", "").startswith("0" * 24):
+            return unmeasurable("MALFORMED_EVIDENCE", "leading bytes do not encode the declared address type")
+        if oracle.get("shape", "").endswith("_6_fields") and oracle.get("fields_served") != 6:
+            return unmeasurable("MALFORMED_EVIDENCE", f"expected 6 fields, served {oracle.get('fields_served')}")
+
+    # Observability references: the omission itself is refused, before anything else.
+    if "registry_ref" in action:
+        ref = action["registry_ref"]
+        if set(ref.replace("0x", "")) == {"0"}:
+            return reject("REFERENCE_MISSING", "required registry reference is zeroed")
+        target = state.get(action.get("target"), {})
+        bound = target.get("bound_registry_ref")
+        if bound and bound != ref:
+            return reject("REFERENCE_MISMATCH", f"reference diverges from the one bound to this context ({bound})")
+
+    # Principal binding.
+    if auth.get("decision_for") and auth["decision_for"] != action.get("actor"):
+        return reject("PRINCIPAL_MISMATCH", f"decision names agent {auth['decision_for']}, actor differs")
+    if "required_signer" in action and auth.get("connected_device_derives") not in (None, action["required_signer"]):
+        return reject("PRINCIPAL_MISMATCH", "connected device derives a different key; wrong device")
+
+    # Replay.
+    if auth.get("consumed"):
+        return reject("REPLAY_CONSUMED", "this one-time authorization was already used")
+    if auth.get("session_secret") and auth.get("current_session"):
+        if auth["session_secret"] != f"SECRET_OF_SESSION_{auth['current_session']}":
+            return reject("REPLAY_CONSUMED", "secret belongs to a previous session")
+
+    # Freshness.
+    if "decision_written_at" in auth:
+        from datetime import datetime
+        age = (datetime.fromisoformat(state["now"].replace("Z", "+00:00"))
+               - datetime.fromisoformat(auth["decision_written_at"].replace("Z", "+00:00"))).total_seconds()
+        if age > auth["freshness_bound_seconds"]:
+            return reject("STALE_DECISION", f"decision is {int(age)}s old, freshness bound exceeded")
+
+    # Context: signature validity alone never suffices; the state must carry the action.
+    target = state.get(action.get("target"), {})
+    if target.get("settled"):
+        return reject("CONTEXT_NOT_SUPPORTED", "target auction is settled; this action replays a closed context")
+    if "ceiling" in target and int(action.get("amount", 0)) > int(target["ceiling"]):
+        return reject("CONTEXT_NOT_SUPPORTED", f"amount exceeds the ceiling the state carries ({target['ceiling']})")
+
+    return {"verdict": "PASS", "code": None, "reason": "context supports the action"}

--- a/conformance/negative/reference_adapter.py
+++ b/conformance/negative/reference_adapter.py
@@ -11,10 +11,10 @@ def evaluate(vector):
     action, auth, state = inp.get("action", {}), inp.get("authorization", {}), inp.get("state", {})
 
     def reject(code, reason):
-        return {"verdict": "REJECT", "code": code, "reason": reason}
+        return {"verdict": "REJECT", "code": code, "entry_point": "reference_adapter.decide", "reason": reason}
 
     def unmeasurable(code, reason):
-        return {"verdict": "UNMEASURABLE", "code": code, "reason": reason}
+        return {"verdict": "UNMEASURABLE", "code": code, "entry_point": "reference_adapter.decide", "reason": reason}
 
     # Evidence shape first: fail closed on what cannot be decoded, with its own code.
     oracle = state.get("oracle_response", "ABSENT_KEY")
@@ -64,4 +64,4 @@ def evaluate(vector):
     if "ceiling" in target and int(action.get("amount", 0)) > int(target["ceiling"]):
         return reject("CONTEXT_NOT_SUPPORTED", f"amount exceeds the ceiling the state carries ({target['ceiling']})")
 
-    return {"verdict": "PASS", "code": None, "reason": "context supports the action"}
+    return {"verdict": "PASS", "code": None, "entry_point": "reference_adapter.decide", "reason": "context supports the action"}

--- a/conformance/negative/runner.py
+++ b/conformance/negative/runner.py
@@ -98,7 +98,9 @@ def main() -> int:
         exp = v["expected"]
         # The suite certifies an enforcement layer, not a test double (review 4996153628):
         # every adapter answer must name the production entry point it dispatched through.
-        ep = out.get("entry_point")
+        # A name made of spaces is not a name: `if not ep` accepts "   ", and the field
+        # the suite treats as structural would be satisfied by whitespace.
+        ep = (out.get("entry_point") or "").strip()
         if not ep:
             failures.append((v["id"], "adapter reported no entry_point - cannot tell the enforcement layer from a test double"))
             continue

--- a/conformance/negative/runner.py
+++ b/conformance/negative/runner.py
@@ -3,15 +3,20 @@
 
 Loads the vector suite, calls one implementation adapter per vector, and fails on:
   - any verdict mismatch,
-  - any failure-code mismatch,
+  - any failure-code mismatch (positive controls included),
   - any missing reason substring (a right verdict for a wrong reason is a latent bug),
-  - any category lacking its POSITIVE CONTROL.
+  - any category lacking its POSITIVE CONTROL (a control counts only if it expects PASS),
+  - any adapter answer that names no entry_point, and any category whose positive
+    controls dispatched through a different entry point than its negative vectors
+    (a suite that certifies a test double certifies nothing - review 4996153628).
 
 The last rule is structural, not cosmetic: a suite made only of must-reject inputs cannot
 distinguish an enforcement layer that works from one that rejects everything.
 
 Adapter contract: a Python file exposing
-    evaluate(vector: dict) -> {"verdict": "PASS|REJECT|UNMEASURABLE", "code": str|None, "reason": str}
+    evaluate(vector: dict) -> {"verdict": "PASS|REJECT|UNMEASURABLE", "code": str|None,
+                               "reason": str, "entry_point": str}
+where entry_point names the production entry point the adapter dispatched through.
 
 Usage:
     python runner.py --adapter path/to/adapter.py [--vectors vectors/negative_vectors.json]
@@ -27,6 +32,8 @@ HERE = Path(__file__).parent
 
 
 def load_adapter(path: Path):
+    # An adapter spanning several files must be able to import its siblings (review 4996153628).
+    sys.path.insert(0, str(path.resolve().parent))
     spec = importlib.util.spec_from_file_location("acs_adapter", path)
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
@@ -48,7 +55,10 @@ def main() -> int:
     # Structural gate first: every category present must carry a positive control.
     cats = defaultdict(lambda: {"neg": 0, "pos": 0})
     for v in vectors:
-        cats[v["category"]]["pos" if v.get("positive_control") else "neg"] += 1
+        # A declared flag is not a positive control; only an expected PASS is (review 4996153628:
+        # a must-reject vector flagged positive_control satisfied the gate with zero must-pass inputs).
+        is_pos = v.get("positive_control") and v["expected"]["verdict"] == "PASS"
+        cats[v["category"]]["pos" if is_pos else "neg"] += 1
     missing = [c for c, k in sorted(cats.items()) if k["pos"] == 0]
     if missing:
         print(f"SUITE INVALID: categories without a positive control: {missing}")
@@ -56,6 +66,7 @@ def main() -> int:
         return 2
 
     failures = []
+    entry_points = defaultdict(lambda: {"pos": set(), "neg": set()})
     for v in vectors:
         try:
             out = adapter.evaluate(v) or {}
@@ -63,10 +74,19 @@ def main() -> int:
             failures.append((v["id"], f"adapter raised {type(e).__name__}: {e}"))
             continue
         exp = v["expected"]
+        # The suite certifies an enforcement layer, not a test double (review 4996153628):
+        # every adapter answer must name the production entry point it dispatched through.
+        ep = out.get("entry_point")
+        if not ep:
+            failures.append((v["id"], "adapter reported no entry_point - cannot tell the enforcement layer from a test double"))
+            continue
+        entry_points[v["category"]]["pos" if v.get("positive_control") else "neg"].add(ep)
         if out.get("verdict") != exp["verdict"]:
             failures.append((v["id"], f"verdict {out.get('verdict')!r} != expected {exp['verdict']!r}"))
             continue
-        if exp["verdict"] != "PASS":
+        # code and reason are compared on PASS vectors too (review 4996153628: a positive
+        # control's code field previously went uncompared).
+        if True:
             if out.get("code") != exp.get("code"):
                 failures.append((v["id"], f"code {out.get('code')!r} != expected {exp.get('code')!r}"))
                 continue
@@ -75,6 +95,10 @@ def main() -> int:
                 if needle.lower() not in reason:
                     failures.append((v["id"], f"reason does not mention {needle!r}: {reason[:120]!r}"))
                     break
+
+    for c, k in sorted(entry_points.items()):
+        if k["pos"] and k["neg"] and k["pos"] != k["neg"]:
+            failures.append((f"cat{c}", f"positive controls resolved through {sorted(k['pos'])} but negatives through {sorted(k['neg'])} - the gate certified a different code path than the one negatively tested"))
 
     print(f"{len(vectors) - len(failures)}/{len(vectors)} vectors conform "
           f"({sum(k['pos'] for k in cats.values())} positive controls across {len(cats)} categories)")

--- a/conformance/negative/runner.py
+++ b/conformance/negative/runner.py
@@ -14,9 +14,13 @@ The last rule is structural, not cosmetic: a suite made only of must-reject inpu
 distinguish an enforcement layer that works from one that rejects everything.
 
 Adapter contract: a Python file exposing
-    evaluate(vector: dict) -> {"verdict": "PASS|REJECT|UNMEASURABLE", "code": str|None,
-                               "reason": str, "entry_point": str}
-where entry_point names the production entry point the adapter dispatched through.
+    evaluate(question: dict) -> {"verdict": "PASS|REJECT|UNMEASURABLE", "code": str|None,
+                                 "reason": str, "entry_point": str}
+where question carries only {"id", "category", "input"} - the expected verdict and the
+control flag never leave the runner, so an adapter that would derive its verdict from
+the answer has nothing to derive it from (review 5444732337, run against 459ec820:
+a six-line answer-key adapter scored 18/18 while enforcing nothing) - and entry_point
+names the production entry point the adapter dispatched through.
 
 Usage:
     python runner.py --adapter path/to/adapter.py [--vectors vectors/negative_vectors.json]
@@ -42,6 +46,15 @@ def load_adapter(path: Path):
     return mod
 
 
+def is_positive_control(v):
+    """A positive control is DECLARED and EXPECTS PASS - decided once, in the one function
+    both sites call (review 5444732337: the structural gate applied this rule while the
+    entry-point bucketing read the declared flag alone, so a must-reject vector carrying
+    the flag was refused a place in the count and still landed in the positive bucket).
+    A declared flag is not a positive control; only an expected PASS is (review 4996153628)."""
+    return bool(v.get("positive_control")) and v["expected"]["verdict"] == "PASS"
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--adapter", required=True, type=Path)
@@ -52,13 +65,18 @@ def main() -> int:
     vectors = suite["vectors"]
     adapter = load_adapter(args.adapter)
 
+    # An empty suite discriminates nothing, and the count it prints is what hides that:
+    # "0/0 vectors conform" with a zero exit reads exactly like a suite that passed.
+    # The rule the gate below enforces per category has to hold for the suite itself.
+    if not vectors:
+        print("SUITE INVALID: no vectors. An empty suite cannot distinguish an enforcement "
+              "layer from one that does nothing, and reports a clean run either way.")
+        return 2
+
     # Structural gate first: every category present must carry a positive control.
     cats = defaultdict(lambda: {"neg": 0, "pos": 0})
     for v in vectors:
-        # A declared flag is not a positive control; only an expected PASS is (review 4996153628:
-        # a must-reject vector flagged positive_control satisfied the gate with zero must-pass inputs).
-        is_pos = v.get("positive_control") and v["expected"]["verdict"] == "PASS"
-        cats[v["category"]]["pos" if is_pos else "neg"] += 1
+        cats[v["category"]]["pos" if is_positive_control(v) else "neg"] += 1
     missing = [c for c, k in sorted(cats.items()) if k["pos"] == 0]
     if missing:
         print(f"SUITE INVALID: categories without a positive control: {missing}")
@@ -68,10 +86,14 @@ def main() -> int:
     failures = []
     entry_points = defaultdict(lambda: {"pos": set(), "neg": set()})
     for v in vectors:
+        # The adapter is never handed the answer: expected verdict and control flag stay in
+        # the runner, so the answer-key family stops being something to detect and becomes
+        # something that cannot be expressed (review 5444732337).
         try:
-            out = adapter.evaluate(v) or {}
-        except Exception as e:  # an adapter crash is a failure, never a skip
-            failures.append((v["id"], f"adapter raised {type(e).__name__}: {e}"))
+            question = {"id": v["id"], "category": v["category"], "input": v["input"]}
+            out = adapter.evaluate(question) or {}
+        except Exception as e:  # an adapter crash - or a malformed vector - is a failure, never a skip
+            failures.append((v.get("id", "?"), f"adapter raised {type(e).__name__}: {e}"))
             continue
         exp = v["expected"]
         # The suite certifies an enforcement layer, not a test double (review 4996153628):
@@ -80,31 +102,37 @@ def main() -> int:
         if not ep:
             failures.append((v["id"], "adapter reported no entry_point - cannot tell the enforcement layer from a test double"))
             continue
-        entry_points[v["category"]]["pos" if v.get("positive_control") else "neg"].add(ep)
+        entry_points[v["category"]]["pos" if is_positive_control(v) else "neg"].add(ep)
         if out.get("verdict") != exp["verdict"]:
             failures.append((v["id"], f"verdict {out.get('verdict')!r} != expected {exp['verdict']!r}"))
             continue
         # code and reason are compared on PASS vectors too (review 4996153628: a positive
-        # control's code field previously went uncompared).
-        if True:
-            if out.get("code") != exp.get("code"):
-                failures.append((v["id"], f"code {out.get('code')!r} != expected {exp.get('code')!r}"))
-                continue
-            reason = (out.get("reason") or "").lower()
-            for needle in exp.get("reason_must_mention", []):
-                if needle.lower() not in reason:
-                    failures.append((v["id"], f"reason does not mention {needle!r}: {reason[:120]!r}"))
-                    break
+        # control's code field previously went uncompared; the always-true conditional that
+        # wrapped this block is gone - review 5444732337 called it, cosmetic and right).
+        if out.get("code") != exp.get("code"):
+            failures.append((v["id"], f"code {out.get('code')!r} != expected {exp.get('code')!r}"))
+            continue
+        reason = (out.get("reason") or "").lower()
+        for needle in exp.get("reason_must_mention", []):
+            if needle.lower() not in reason:
+                failures.append((v["id"], f"reason does not mention {needle!r}: {reason[:120]!r}"))
+                break
 
+    # Category failures are counted apart from vector failures: subtracting them from the
+    # vector total printed "17/18 vectors conform" on a suite whose 18 vectors all conformed,
+    # which is a wrong number reported by the very line that is supposed to make the run legible.
+    category_failures = []
     for c, k in sorted(entry_points.items()):
         if k["pos"] and k["neg"] and k["pos"] != k["neg"]:
-            failures.append((f"cat{c}", f"positive controls resolved through {sorted(k['pos'])} but negatives through {sorted(k['neg'])} - the gate certified a different code path than the one negatively tested"))
+            category_failures.append((f"cat{c}", f"positive controls resolved through {sorted(k['pos'])} but negatives through {sorted(k['neg'])} - the gate certified a different code path than the one negatively tested"))
 
     print(f"{len(vectors) - len(failures)}/{len(vectors)} vectors conform "
           f"({sum(k['pos'] for k in cats.values())} positive controls across {len(cats)} categories)")
     for vid, why in failures:
         print(f"  FAIL {vid}: {why}")
-    return 1 if failures else 0
+    for cid, why in category_failures:
+        print(f"  FAIL {cid}: {why}")
+    return 1 if (failures or category_failures) else 0
 
 
 if __name__ == "__main__":

--- a/conformance/negative/runner.py
+++ b/conformance/negative/runner.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Negative conformance runner (issue #29, gap #19).
+
+Loads the vector suite, calls one implementation adapter per vector, and fails on:
+  - any verdict mismatch,
+  - any failure-code mismatch,
+  - any missing reason substring (a right verdict for a wrong reason is a latent bug),
+  - any category lacking its POSITIVE CONTROL.
+
+The last rule is structural, not cosmetic: a suite made only of must-reject inputs cannot
+distinguish an enforcement layer that works from one that rejects everything.
+
+Adapter contract: a Python file exposing
+    evaluate(vector: dict) -> {"verdict": "PASS|REJECT|UNMEASURABLE", "code": str|None, "reason": str}
+
+Usage:
+    python runner.py --adapter path/to/adapter.py [--vectors vectors/negative_vectors.json]
+"""
+import argparse
+import importlib.util
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+HERE = Path(__file__).parent
+
+
+def load_adapter(path: Path):
+    spec = importlib.util.spec_from_file_location("acs_adapter", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    if not hasattr(mod, "evaluate"):
+        sys.exit(f"FATAL: adapter {path} exposes no evaluate(vector)")
+    return mod
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--adapter", required=True, type=Path)
+    ap.add_argument("--vectors", type=Path, default=HERE / "vectors" / "negative_vectors.json")
+    args = ap.parse_args()
+
+    suite = json.loads(args.vectors.read_text(encoding="utf-8"))
+    vectors = suite["vectors"]
+    adapter = load_adapter(args.adapter)
+
+    # Structural gate first: every category present must carry a positive control.
+    cats = defaultdict(lambda: {"neg": 0, "pos": 0})
+    for v in vectors:
+        cats[v["category"]]["pos" if v.get("positive_control") else "neg"] += 1
+    missing = [c for c, k in sorted(cats.items()) if k["pos"] == 0]
+    if missing:
+        print(f"SUITE INVALID: categories without a positive control: {missing}")
+        print("A suite of pure rejections cannot tell a working layer from one that rejects everything.")
+        return 2
+
+    failures = []
+    for v in vectors:
+        try:
+            out = adapter.evaluate(v) or {}
+        except Exception as e:  # an adapter crash is a failure, never a skip
+            failures.append((v["id"], f"adapter raised {type(e).__name__}: {e}"))
+            continue
+        exp = v["expected"]
+        if out.get("verdict") != exp["verdict"]:
+            failures.append((v["id"], f"verdict {out.get('verdict')!r} != expected {exp['verdict']!r}"))
+            continue
+        if exp["verdict"] != "PASS":
+            if out.get("code") != exp.get("code"):
+                failures.append((v["id"], f"code {out.get('code')!r} != expected {exp.get('code')!r}"))
+                continue
+            reason = (out.get("reason") or "").lower()
+            for needle in exp.get("reason_must_mention", []):
+                if needle.lower() not in reason:
+                    failures.append((v["id"], f"reason does not mention {needle!r}: {reason[:120]!r}"))
+                    break
+
+    print(f"{len(vectors) - len(failures)}/{len(vectors)} vectors conform "
+          f"({sum(k['pos'] for k in cats.values())} positive controls across {len(cats)} categories)")
+    for vid, why in failures:
+        print(f"  FAIL {vid}: {why}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conformance/negative/selftest.py
+++ b/conformance/negative/selftest.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Negative controls for the runner and the reference adapter.
+
+A suite that has only ever been run against an implementation which passes it has
+not been shown to discriminate. A verifier that rejected every input would pass every
+must-reject vector ever written, and nothing here would notice. So every case below is
+one the suite MUST refuse, paired with the one case it must accept, and a green result
+means the gate is live rather than absent.
+
+Three families, and the third is the one that finds vectors nobody wrote:
+
+  FAKE ADAPTERS      implementations that enforce nothing, or that satisfy the letter of
+                     the adapter contract while defeating its purpose.
+  RUNNER GUARDS      inputs the runner itself must refuse before any adapter is consulted:
+                     an empty suite, and a category with no positive control.
+  ADAPTER MUTANTS    each deletes exactly one check from the reference adapter. The suite
+                     has to go red for every one of them. A surviving mutant is not a
+                     tolerable gap - it is a vector nobody wrote, and it names which one.
+
+Every case declares the outcome it requires, so a case that starts passing for the wrong
+reason shows up as a changed count rather than as silence.
+
+    python conformance/negative/selftest.py
+"""
+import json
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).parent
+RUNNER = HERE / "runner.py"
+ADAPTER = HERE / "reference_adapter.py"
+VECTORS = HERE / "vectors" / "negative_vectors.json"
+
+_IMPORT_REAL = (
+    "import sys; sys.path.insert(0, r'%s')\n" % HERE.resolve()
+    + "from reference_adapter import evaluate as _inner\n"
+)
+
+# Adapters the suite must refuse. Each one is a way of being green while enforcing
+# nothing, or of satisfying the entry-point contract without dispatching through the
+# thing it names.
+FAKE_ADAPTERS = {
+    "answer_key": (
+        "# Would echo the expected verdict back. The runner never hands it one, so it\n"
+        "# has nothing to echo and fails on its first call.\n"
+        "def evaluate(q):\n"
+        "    e = q['expected']\n"
+        "    return {'verdict': e['verdict'], 'code': e.get('code'),\n"
+        "            'reason': ' '.join(e.get('reason_must_mention', [])),\n"
+        "            'entry_point': 'acme.enforcement.decide'}\n"
+    ),
+    "reject_everything": (
+        "# The case the positive controls exist for: refusing everything is not enforcing.\n"
+        "def evaluate(q):\n"
+        "    return {'verdict': 'REJECT', 'code': 'CONTEXT_NOT_SUPPORTED',\n"
+        "            'reason': 'context does not carry this action',\n"
+        "            'entry_point': 'acme.enforcement.decide'}\n"
+    ),
+    "allow_everything": (
+        "def evaluate(q):\n"
+        "    return {'verdict': 'PASS', 'code': None, 'reason': 'ok',\n"
+        "            'entry_point': 'acme.enforcement.decide'}\n"
+    ),
+    "no_entry_point": (
+        _IMPORT_REAL
+        + "def evaluate(q):\n"
+        "    out = dict(_inner(q)); out.pop('entry_point', None); return out\n"
+    ),
+    "blank_entry_point": (
+        "# A name made of spaces is not a name. `if not ep` accepts it; a stripped test does not.\n"
+        + _IMPORT_REAL
+        + "def evaluate(q):\n"
+        "    out = dict(_inner(q)); out['entry_point'] = '   '; return out\n"
+    ),
+    "split_path": (
+        "# Answers the must-pass inputs from a second path: a test double wired in beside\n"
+        "# the enforcement layer, which is what the entry-point comparison is for.\n"
+        + _IMPORT_REAL
+        + "def evaluate(q):\n"
+        "    out = dict(_inner(q))\n"
+        "    if out['verdict'] == 'PASS':\n"
+        "        out['entry_point'] = 'test_double.allow'\n"
+        "    return out\n"
+    ),
+    "right_verdict_wrong_reason": (
+        "# A right verdict for a wrong reason is a latent bug, and reason_must_mention exists\n"
+        "# to catch exactly this.\n"
+        + _IMPORT_REAL
+        + "def evaluate(q):\n"
+        "    out = dict(_inner(q)); out['reason'] = 'refused'; return out\n"
+    ),
+    "right_verdict_wrong_code": (
+        _IMPORT_REAL
+        + "def evaluate(q):\n"
+        "    out = dict(_inner(q))\n"
+        "    if out.get('code'):\n"
+        "        out['code'] = 'CONTEXT_NOT_SUPPORTED'\n"
+        "    return out\n"
+    ),
+}
+
+# Suites the runner must refuse before consulting any adapter.
+def _suite_without_positive_control(vectors):
+    """Every category keeps its must-reject vectors; the positive controls go."""
+    return [v for v in vectors if v["expected"]["verdict"] != "PASS"]
+
+
+RUNNER_GUARDS = {
+    "empty_suite": (lambda vs: []),
+    "no_positive_control": _suite_without_positive_control,
+}
+
+# Each mutant deletes ONE check from the reference adapter by rewriting a single line
+# of its source. The suite must go red for every one. The pattern is matched against
+# the file as shipped: a mutant that no longer applies is reported as such rather than
+# counted as killed, because a rule that silently stops being tested is worse than one
+# that fails.
+ADAPTER_MUTANTS = {
+    "drop_unreadable_state": (
+        r'if oracle is None:', 'if False:'),
+    "drop_address_shape_check": (
+        r'if oracle\.get\("shape"\) == "address" and not oracle\.get\("bytes_hex", ""\)\.startswith\("0" \* 24\):',
+        'if False:'),
+    "drop_field_count_check": (
+        r'if oracle\.get\("shape", ""\)\.endswith\("_6_fields"\) and oracle\.get\("fields_served"\) != 6:',
+        'if False:'),
+    "drop_zeroed_reference_check": (
+        r'if set\(ref\.replace\("0x", ""\)\) == \{"0"\}:', 'if False:'),
+    "drop_reference_binding_check": (
+        r'if bound and bound != ref:', 'if False:'),
+    "drop_principal_binding_check": (
+        r'if auth\.get\("decision_for"\) and auth\["decision_for"\] != action\.get\("actor"\):',
+        'if False:'),
+    "trust_an_unmeasured_device": (
+        r'if derived is None:', 'if False:'),
+    "drop_wrong_device_check": (
+        r'if derived != action\["required_signer"\]:', 'if False:'),
+    "drop_replay_check": (
+        r'if auth\.get\("consumed"\):', 'if False:'),
+    "drop_session_binding_check": (
+        r'if auth\["session_secret"\] != f"SECRET_OF_SESSION_\{auth\[.current_session.\]\}":',
+        'if False:'),
+    "drop_freshness_check": (
+        r'if age > auth\["freshness_bound_seconds"\]:', 'if False:'),
+    "drop_settled_context_check": (
+        r'if target\.get\("settled"\):', 'if False:'),
+    "drop_ceiling_check": (
+        r'if "ceiling" in target and int\(action\.get\("amount", 0\)\) > int\(target\["ceiling"\]\):',
+        'if False:'),
+}
+
+
+def run(adapter: Path, vectors: Path = VECTORS):
+    cmd = [sys.executable, str(RUNNER), "--adapter", str(adapter), "--vectors", str(vectors)]
+    p = subprocess.run(cmd, capture_output=True, text=True)
+    return p.returncode, (p.stdout + p.stderr).strip()
+
+
+def main() -> int:
+    suite = json.loads(VECTORS.read_text(encoding="utf-8"))
+    source = ADAPTER.read_text(encoding="utf-8")
+    held, failed = 0, []
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+
+        # The acceptant. Without it, everything below could be green because the suite
+        # refuses its input unconditionally, and no count here would say so.
+        code, out = run(ADAPTER)
+        if code == 0:
+            held += 1
+            print("  held  reference adapter is accepted (the pair for every refusal below)")
+        else:
+            failed.append(("reference_adapter", "the shipped adapter must pass, got exit "
+                           f"{code}: {out.splitlines()[0] if out else ''}"))
+
+        for name, body in FAKE_ADAPTERS.items():
+            path = tmp / f"fake_{name}.py"
+            path.write_text(body, encoding="utf-8")
+            code, out = run(path)
+            if code != 0:
+                held += 1
+                print(f"  held  fake adapter refused: {name}")
+            else:
+                failed.append((f"fake:{name}", "accepted an implementation that must be refused"))
+
+        for name, build in RUNNER_GUARDS.items():
+            path = tmp / f"vectors_{name}.json"
+            path.write_text(json.dumps({**suite, "vectors": build(suite["vectors"])}),
+                            encoding="utf-8")
+            code, out = run(ADAPTER, path)
+            if code != 0:
+                held += 1
+                print(f"  held  runner refused the suite: {name}")
+            else:
+                failed.append((f"guard:{name}", "ran a suite that cannot discriminate, and exited 0"))
+
+        for name, (pattern, replacement) in ADAPTER_MUTANTS.items():
+            mutated, n = re.subn(pattern, replacement, source, count=1)
+            if n != 1:
+                failed.append((f"mutant:{name}",
+                               "pattern no longer matches the adapter - the rule it deletes is "
+                               "not being tested any more, update or remove this mutant"))
+                continue
+            path = tmp / f"mutant_{name}.py"
+            path.write_text(mutated, encoding="utf-8")
+            code, out = run(path)
+            if code != 0:
+                held += 1
+                print(f"  held  mutant killed: {name}")
+            else:
+                failed.append((f"mutant:{name}",
+                               "survived - no vector exercises the check it deletes"))
+
+    total = held + len(failed)
+    print(f"\n{held}/{total} negative controls held")
+    for name, why in failed:
+        print(f"  FAIL {name}: {why}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conformance/negative/vector.schema.json
+++ b/conformance/negative/vector.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ACS negative conformance vector suite",
+  "type": "object",
+  "required": ["suite", "vectors"],
+  "properties": {
+    "suite": { "type": "string" },
+    "vectors": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "category", "description", "input", "expected", "positive_control"],
+        "properties": {
+          "id": { "type": "string", "pattern": "^(neg|pos)-cat[0-9]+-[0-9]{3}$" },
+          "category": { "type": "integer", "minimum": 1, "maximum": 6 },
+          "description": { "type": "string", "minLength": 20 },
+          "input": {
+            "type": "object",
+            "required": ["action", "authorization", "state"],
+            "properties": {
+              "action": { "type": "object" },
+              "authorization": { "type": "object" },
+              "state": { "type": "object" }
+            }
+          },
+          "expected": {
+            "type": "object",
+            "required": ["verdict"],
+            "properties": {
+              "verdict": { "enum": ["PASS", "REJECT", "UNMEASURABLE"] },
+              "code": { "enum": ["CONTEXT_NOT_SUPPORTED", "REPLAY_CONSUMED", "STALE_DECISION", "PRINCIPAL_MISMATCH", "REFERENCE_MISSING", "REFERENCE_MISMATCH", "MALFORMED_EVIDENCE", "ORACLE_UNAVAILABLE"] },
+              "reason_must_mention": { "type": "array", "items": { "type": "string" } }
+            }
+          },
+          "positive_control": { "type": "boolean" }
+        }
+      }
+    }
+  }
+}

--- a/conformance/negative/vectors/negative_vectors.json
+++ b/conformance/negative/vectors/negative_vectors.json
@@ -1,0 +1,513 @@
+{
+  "$schema": "../vector.schema.json",
+  "suite": "enforcement-negative-v0",
+  "vectors": [
+    {
+      "id": "neg-cat1-001",
+      "category": 1,
+      "description": "Correctly-signed action targeting an item whose state no longer carries it: the auction is already settled. Signature verification alone passes; only consulting state catches it.",
+      "input": {
+        "action": {
+          "type": "commit_funds",
+          "target": "auction-41",
+          "amount": "1000"
+        },
+        "authorization": {
+          "signature": "VALID",
+          "signer": "agent-A",
+          "scope": "auction-41"
+        },
+        "state": {
+          "auction-41": {
+            "open": false,
+            "settled": true
+          }
+        }
+      },
+      "expected": {
+        "verdict": "REJECT",
+        "code": "CONTEXT_NOT_SUPPORTED",
+        "reason_must_mention": [
+          "settled"
+        ]
+      },
+      "positive_control": false
+    },
+    {
+      "id": "neg-cat1-002",
+      "category": 1,
+      "description": "Correctly-signed action exceeding a declared bound: amount above the ceiling the state carries. Almost right: same signer, same target, open state.",
+      "input": {
+        "action": {
+          "type": "commit_funds",
+          "target": "auction-42",
+          "amount": "9000"
+        },
+        "authorization": {
+          "signature": "VALID",
+          "signer": "agent-A",
+          "scope": "auction-42"
+        },
+        "state": {
+          "auction-42": {
+            "open": true,
+            "settled": false,
+            "ceiling": "5000"
+          }
+        }
+      },
+      "expected": {
+        "verdict": "REJECT",
+        "code": "CONTEXT_NOT_SUPPORTED",
+        "reason_must_mention": [
+          "ceiling"
+        ]
+      },
+      "positive_control": false
+    },
+    {
+      "id": "pos-cat1-001",
+      "category": 1,
+      "description": "POSITIVE CONTROL. Identical to neg-cat1-002 except the amount sits under the ceiling. MUST pass: an enforcement layer that rejects this is indistinguishable from one that rejects everything.",
+      "input": {
+        "action": {
+          "type": "commit_funds",
+          "target": "auction-42",
+          "amount": "1000"
+        },
+        "authorization": {
+          "signature": "VALID",
+          "signer": "agent-A",
+          "scope": "auction-42"
+        },
+        "state": {
+          "auction-42": {
+            "open": true,
+            "settled": false,
+            "ceiling": "5000"
+          }
+        }
+      },
+      "expected": {
+        "verdict": "PASS"
+      },
+      "positive_control": true
+    },
+    {
+      "id": "neg-cat2-001",
+      "category": 2,
+      "description": "Replayed authorization: the same one-time approval presented for a second act. One authorization covers one act; the second presentation must fail even though every byte is valid.",
+      "input": {
+        "action": {
+          "type": "commit_funds",
+          "target": "auction-43",
+          "amount": "1000"
+        },
+        "authorization": {
+          "signature": "VALID",
+          "signer": "agent-A",
+          "one_time_id": "auth-777",
+          "consumed": true
+        },
+        "state": {
+          "auction-43": {
+            "open": true,
+            "settled": false
+          }
+        }
+      },
+      "expected": {
+        "verdict": "REJECT",
+        "code": "REPLAY_CONSUMED",
+        "reason_must_mention": [
+          "already"
+        ]
+      },
+      "positive_control": false
+    },
+    {
+      "id": "neg-cat2-002",
+      "category": 2,
+      "description": "Replay across sessions: an approval secret captured from a previous armed session, structurally valid, presented by a fresh confirmer. The session binding, not the secret's shape, is what must be checked.",
+      "input": {
+        "action": {
+          "type": "confirm_transaction",
+          "target": "tx-pending-9"
+        },
+        "authorization": {
+          "signature": "VALID",
+          "session_secret": "SECRET_OF_SESSION_N_MINUS_1",
+          "current_session": "N"
+        },
+        "state": {
+          "tx-pending-9": {
+            "awaiting_confirmation": true,
+            "session": "N"
+          }
+        }
+      },
+      "expected": {
+        "verdict": "REJECT",
+        "code": "REPLAY_CONSUMED",
+        "reason_must_mention": [
+          "session"
+        ]
+      },
+      "positive_control": false
+    },
+    {
+      "id": "neg-cat3-001",
+      "category": 3,
+      "description": "Stale decision: evidence older than the declared freshness bound. The decision was genuine when written; only its age disqualifies it. Expiry only — revocation vectors are a declared gap, see README.",
+      "input": {
+        "action": {
+          "type": "launch_bidder",
+          "target": "auction-44"
+        },
+        "authorization": {
+          "signature": "VALID",
+          "decision_written_at": "2026-08-16T14:46:02Z",
+          "freshness_bound_seconds": 900
+        },
+        "state": {
+          "now": "2026-08-16T15:15:08Z",
+          "auction-44": {
+            "open": true
+          }
+        }
+      },
+      "expected": {
+        "verdict": "REJECT",
+        "code": "STALE_DECISION",
+        "reason_must_mention": [
+          "fresh"
+        ]
+      },
+      "positive_control": false
+    },
+    {
+      "id": "pos-cat3-001",
+      "category": 3,
+      "description": "POSITIVE CONTROL. Identical decision, re-issued inside the freshness bound. MUST pass.",
+      "input": {
+        "action": {
+          "type": "launch_bidder",
+          "target": "auction-44"
+        },
+        "authorization": {
+          "signature": "VALID",
+          "decision_written_at": "2026-08-16T15:16:00Z",
+          "freshness_bound_seconds": 900
+        },
+        "state": {
+          "now": "2026-08-16T15:16:25Z",
+          "auction-44": {
+            "open": true
+          }
+        }
+      },
+      "expected": {
+        "verdict": "PASS"
+      },
+      "positive_control": true
+    },
+    {
+      "id": "neg-cat4-001",
+      "category": 4,
+      "description": "Approval bound to the wrong principal: the decision names agent-B, the actor is agent-A. Everything else matches.",
+      "input": {
+        "action": {
+          "type": "launch_bidder",
+          "target": "auction-45",
+          "actor": "agent-A"
+        },
+        "authorization": {
+          "signature": "VALID",
+          "decision_for": "agent-B"
+        },
+        "state": {
+          "auction-45": {
+            "open": true
+          }
+        }
+      },
+      "expected": {
+        "verdict": "REJECT",
+        "code": "PRINCIPAL_MISMATCH",
+        "reason_must_mention": [
+          "agent"
+        ]
+      },
+      "positive_control": false
+    },
+    {
+      "id": "neg-cat4-002",
+      "category": 4,
+      "description": "Wrong signing device: the operation requires the device holding key K1, the connected device derives K2. The check must happen by reading the device, never by asking the operator which one is plugged in.",
+      "input": {
+        "action": {
+          "type": "sign_transaction",
+          "required_signer": "0xAAAA"
+        },
+        "authorization": {
+          "connected_device_derives": "0xBBBB"
+        },
+        "state": {}
+      },
+      "expected": {
+        "verdict": "REJECT",
+        "code": "PRINCIPAL_MISMATCH",
+        "reason_must_mention": [
+          "device"
+        ]
+      },
+      "positive_control": false
+    },
+    {
+      "id": "neg-cat5-001",
+      "category": 5,
+      "description": "Malformed evidence, regulation length: the payload has exactly the right byte length but does not encode the declared type (leading bytes non-zero where an address encoding requires zeros). A length check alone fails open here.",
+      "input": {
+        "action": {
+          "type": "read_context",
+          "target": "auction-46"
+        },
+        "authorization": {
+          "signature": "VALID"
+        },
+        "state": {
+          "oracle_response": {
+            "shape": "address",
+            "bytes_hex": "ffffffffffffffffffffffff1111111111111111111111111111111111111111"
+          }
+        }
+      },
+      "expected": {
+        "verdict": "UNMEASURABLE",
+        "code": "MALFORMED_EVIDENCE",
+        "reason_must_mention": [
+          "encod"
+        ]
+      },
+      "positive_control": false
+    },
+    {
+      "id": "neg-cat5-002",
+      "category": 5,
+      "description": "Truncated evidence: two fields served where six are declared. The consumer must refuse to conclude, never zero-fill the missing fields.",
+      "input": {
+        "action": {
+          "type": "read_context",
+          "target": "auction-47"
+        },
+        "authorization": {
+          "signature": "VALID"
+        },
+        "state": {
+          "oracle_response": {
+            "shape": "auction_struct_6_fields",
+            "fields_served": 2
+          }
+        }
+      },
+      "expected": {
+        "verdict": "UNMEASURABLE",
+        "code": "MALFORMED_EVIDENCE",
+        "reason_must_mention": [
+          "6"
+        ]
+      },
+      "positive_control": false
+    },
+    {
+      "id": "neg-cat5-003",
+      "category": 5,
+      "description": "Oracle unreachable: the state needed to judge cannot be read at all. Absence of measurement is never a pass, and the code must differ from a measured rejection.",
+      "input": {
+        "action": {
+          "type": "commit_funds",
+          "target": "auction-48",
+          "amount": "1000"
+        },
+        "authorization": {
+          "signature": "VALID",
+          "signer": "agent-A",
+          "scope": "auction-48"
+        },
+        "state": {
+          "oracle_response": null
+        }
+      },
+      "expected": {
+        "verdict": "UNMEASURABLE",
+        "code": "ORACLE_UNAVAILABLE",
+        "reason_must_mention": [
+          "measur"
+        ]
+      },
+      "positive_control": false
+    },
+    {
+      "id": "neg-cat6-001",
+      "category": 6,
+      "description": "Stripped observability reference: the action's required registry reference is zeroed. The enforcement point must refuse the omission itself, before judging anything else.",
+      "input": {
+        "action": {
+          "type": "commit_funds",
+          "target": "auction-49",
+          "amount": "1000",
+          "registry_ref": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "authorization": {
+          "signature": "VALID",
+          "signer": "agent-A",
+          "scope": "auction-49"
+        },
+        "state": {
+          "auction-49": {
+            "open": true
+          }
+        }
+      },
+      "expected": {
+        "verdict": "REJECT",
+        "code": "REFERENCE_MISSING",
+        "reason_must_mention": [
+          "reference"
+        ]
+      },
+      "positive_control": false
+    },
+    {
+      "id": "neg-cat6-002",
+      "category": 6,
+      "description": "Mismatched observability reference: a non-zero reference that diverges from the one already bound to this context by a prior act. Naming something is required; naming a DIFFERENT something must fail.",
+      "input": {
+        "action": {
+          "type": "commit_funds",
+          "target": "auction-50",
+          "amount": "2000",
+          "registry_ref": "0xbbbb..."
+        },
+        "authorization": {
+          "signature": "VALID",
+          "signer": "agent-B",
+          "scope": "auction-50"
+        },
+        "state": {
+          "auction-50": {
+            "open": true,
+            "bound_registry_ref": "0xaaaa..."
+          }
+        }
+      },
+      "expected": {
+        "verdict": "REJECT",
+        "code": "REFERENCE_MISMATCH",
+        "reason_must_mention": [
+          "bound"
+        ]
+      },
+      "positive_control": false
+    },
+    {
+      "id": "pos-cat6-001",
+      "category": 6,
+      "description": "POSITIVE CONTROL. Same action naming the SAME reference as the one bound. MUST pass: the check is on divergence, not on novelty.",
+      "input": {
+        "action": {
+          "type": "commit_funds",
+          "target": "auction-50",
+          "amount": "2000",
+          "registry_ref": "0xaaaa..."
+        },
+        "authorization": {
+          "signature": "VALID",
+          "signer": "agent-B",
+          "scope": "auction-50"
+        },
+        "state": {
+          "auction-50": {
+            "open": true,
+            "bound_registry_ref": "0xaaaa..."
+          }
+        }
+      },
+      "expected": {
+        "verdict": "PASS"
+      },
+      "positive_control": true
+    },
+    {
+      "id": "pos-cat2-001",
+      "category": 2,
+      "description": "POSITIVE CONTROL. Same shape as neg-cat2-001 but the one-time authorization is unconsumed. MUST pass.",
+      "input": {
+        "action": {
+          "type": "commit_funds",
+          "target": "auction-43",
+          "amount": "1000"
+        },
+        "authorization": {
+          "signature": "VALID",
+          "signer": "agent-A",
+          "one_time_id": "auth-778",
+          "consumed": false
+        },
+        "state": {
+          "auction-43": {
+            "open": true,
+            "settled": false
+          }
+        }
+      },
+      "expected": {
+        "verdict": "PASS"
+      },
+      "positive_control": true
+    },
+    {
+      "id": "pos-cat4-001",
+      "category": 4,
+      "description": "POSITIVE CONTROL. The connected device derives exactly the required key. MUST pass.",
+      "input": {
+        "action": {
+          "type": "sign_transaction",
+          "required_signer": "0xAAAA"
+        },
+        "authorization": {
+          "connected_device_derives": "0xAAAA"
+        },
+        "state": {}
+      },
+      "expected": {
+        "verdict": "PASS"
+      },
+      "positive_control": true
+    },
+    {
+      "id": "pos-cat5-001",
+      "category": 5,
+      "description": "POSITIVE CONTROL. Well-formed evidence of the declared shape (address encoding with zeroed leading bytes). MUST pass: strictness is about shape, not about refusing evidence per se.",
+      "input": {
+        "action": {
+          "type": "read_context",
+          "target": "auction-46"
+        },
+        "authorization": {
+          "signature": "VALID"
+        },
+        "state": {
+          "oracle_response": {
+            "shape": "address",
+            "bytes_hex": "0000000000000000000000001111111111111111111111111111111111111111"
+          }
+        }
+      },
+      "expected": {
+        "verdict": "PASS"
+      },
+      "positive_control": true
+    }
+  ]
+}

--- a/conformance/negative/vectors/negative_vectors.json
+++ b/conformance/negative/vectors/negative_vectors.json
@@ -486,6 +486,27 @@
       "positive_control": true
     },
     {
+      "id": "neg-cat4-003",
+      "category": 4,
+      "description": "No evidence of which device is connected: the operation requires the device holding key K1, and nothing was read about what is plugged in. Absence of a measurement is not a match - the action is refused under the unmeasurable code, not under the mismatch code, because no mismatch was observed.",
+      "input": {
+        "action": {
+          "type": "sign_transaction",
+          "required_signer": "0xAAAA"
+        },
+        "authorization": {},
+        "state": {}
+      },
+      "expected": {
+        "verdict": "UNMEASURABLE",
+        "code": "ORACLE_UNAVAILABLE",
+        "reason_must_mention": [
+          "device"
+        ]
+      },
+      "positive_control": false
+    },
+    {
       "id": "pos-cat5-001",
       "category": 5,
       "description": "POSITIVE CONTROL. Well-formed evidence of the declared shape (address encoding with zeroed leading bytes). MUST pass: strictness is about shape, not about refusing evidence per se.",


### PR DESCRIPTION
Implements the proposal of #29 and begins closing the conformance-suite gap of #19.

What is in here:

- 18 framework-agnostic vectors in JSON across the six categories of #29: 12 must-reject inputs and 6 positive controls, one per category
- a proposed failure code enumeration. Its backbone is one distinction: REJECT (evidence measured and found wrong) is a different verdict from UNMEASURABLE (evidence could not be measured; the action must still be refused, under a distinct code). Collapsing the two either lets unmeasurable inputs fail open, or sends operators hunting for frauds that never happened
- runner.py, which fails the suite on any verdict mismatch, code mismatch, missing reason substring, or any category lacking its positive control. That last rule is structural: a suite made only of must-reject inputs cannot distinguish an enforcement layer that works from one that rejects everything
- reference_adapter.py, a minimal passing implementation, so the suite is executable end to end as shipped: python conformance/negative/runner.py --adapter conformance/negative/reference_adapter.py

Category 3 (expired or revoked mandates) is covered for expiry only. Revocation vectors are a declared gap: the contributing implementation has no revocation mechanism, by documented decision, and vectors for a path never exercised in production would be design fiction. Contributions from implementations that exercise revocation are the way to close it.

Every failure code in the enumeration was produced by a real refusal in a production enforcement layer before it was named here. Vector wording is deliberately implementation-neutral; naming, directory layout and the enumeration itself are all open to review.

---

## Type of change

- [ ] Specification change (schema, hooks, events, AgBOM)
- [ ] Documentation
- [x] Tooling or CI
- [ ] Governance (licensing, security policy, contributor docs)

(Nothing under specification/ or docs/spec/ is touched; the new directory sits at conformance/negative/.)

## Checklist

- [x] Commits are signed off with `git commit -s` (required by the DCO)
- [x] Prose follows STYLE.md
- [ ] `uv run mkdocs build --strict` passes (not run locally; conformance/ sits outside the docs tree, happy to add the check if maintainers want it wired into CI)
- [x] No secrets, tokens, or internal URLs in the diff

## Security

- [x] This change has no security impact

(It adds test vectors and a runner; it changes no normative text and no schema.)