### PR TITLE
Add capability-scoped revocation conformance vectors

### DIFF
--- a/.github/workflows/revocation-conformance.yml
+++ b/.github/workflows/revocation-conformance.yml
@@ -1,0 +1,74 @@
+name: Revocation conformance
+
+on:
+  push:
+    paths:
+      - "conformance/revocation/**"
+      - ".github/workflows/revocation-conformance.yml"
+  pull_request:
+    paths:
+      - "conformance/revocation/**"
+      - ".github/workflows/revocation-conformance.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  conformance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Vectors validate against the schema
+        run: |
+          pip install --quiet jsonschema
+          python - <<'PY'
+          import json, pathlib, sys
+          import jsonschema
+          d = pathlib.Path("conformance/revocation")
+          schema = json.loads((d / "vector.schema.json").read_text())
+          vectors = json.loads((d / "vectors" / "revocation_vectors.json").read_text())["vectors"]
+          bad = []
+          for v in vectors:
+              try:
+                  jsonschema.validate(v, schema)
+              except jsonschema.ValidationError as e:
+                  bad.append(f"{v['id']}: {e.message}")
+          for line in bad:
+              print(line)
+          print(f"{len(vectors) - len(bad)}/{len(vectors)} vectors validate")
+          sys.exit(1 if bad else 0)
+          PY
+
+      - name: Reference adapter conforms
+        run: |
+          python conformance/revocation/runner.py \
+            --adapter conformance/revocation/revocation_adapter.py
+
+      - name: Negative controls hold
+        run: python conformance/revocation/selftest.py
+
+      - name: Manifest matches what is on disk
+        run: |
+          python - <<'PY'
+          import hashlib, json, pathlib, sys
+          d = pathlib.Path("conformance/revocation")
+          pinned = json.loads((d / "MANIFEST.json").read_text())["files"]
+          drift = []
+          for name, digest in pinned.items():
+              hits = [p for p in d.rglob(name) if p.is_file()]
+              if len(hits) != 1:
+                  drift.append(f"{name}: {len(hits)} files match this manifest entry")
+                  continue
+              actual = "sha256:" + hashlib.sha256(hits[0].read_bytes()).hexdigest()
+              if actual != digest:
+                  drift.append(f"{name}: {actual} != pinned {digest}")
+          for line in drift:
+              print(line)
+          print(f"{len(pinned) - len(drift)}/{len(pinned)} files match their pinned digest")
+          sys.exit(1 if drift else 0)
+          PY

--- a/conformance/revocation/MANIFEST.json
+++ b/conformance/revocation/MANIFEST.json
@@ -5,6 +5,7 @@
     "revocation_vectors.json": "sha256:14b9cd8333bca837164dcad90afc53b9dc358199c9edf9f5086e946c7f19d735",
     "vector.schema.json": "sha256:94033577dd8a2e7aa7641798d64921d514d063b576d8c8b206677bec70cbb015",
     "revocation_adapter.py": "sha256:20d94226efeb533e3701dce06147ae0796ccf44c4e9e2c1fef7131d0ff18b70b",
-    "runner.py": "sha256:021034013171d27ff1cfff0f6e8d2a9d2e6aebd32f416693ef692a082509954a"
+    "runner.py": "sha256:021034013171d27ff1cfff0f6e8d2a9d2e6aebd32f416693ef692a082509954a",
+    "selftest.py": "sha256:ef41f284274d793499af530cb9fc68f86e5fab34e17dbcb2b88b558118e28ff4"
   }
 }

--- a/conformance/revocation/MANIFEST.json
+++ b/conformance/revocation/MANIFEST.json
@@ -1,0 +1,10 @@
+{
+  "suite": "enforcement-negative-revocation-v0",
+  "description": "Digest pin for the revocation conformance suite. The runner refuses a vector file that does not match its entry here: a suite editable between publication and use proves nothing about the implementation that ran it.",
+  "files": {
+    "revocation_vectors.json": "sha256:14b9cd8333bca837164dcad90afc53b9dc358199c9edf9f5086e946c7f19d735",
+    "vector.schema.json": "sha256:94033577dd8a2e7aa7641798d64921d514d063b576d8c8b206677bec70cbb015",
+    "revocation_adapter.py": "sha256:20d94226efeb533e3701dce06147ae0796ccf44c4e9e2c1fef7131d0ff18b70b",
+    "runner.py": "sha256:021034013171d27ff1cfff0f6e8d2a9d2e6aebd32f416693ef692a082509954a"
+  }
+}

--- a/conformance/revocation/MANIFEST.json
+++ b/conformance/revocation/MANIFEST.json
@@ -6,6 +6,7 @@
     "vector.schema.json": "sha256:94033577dd8a2e7aa7641798d64921d514d063b576d8c8b206677bec70cbb015",
     "revocation_adapter.py": "sha256:20d94226efeb533e3701dce06147ae0796ccf44c4e9e2c1fef7131d0ff18b70b",
     "runner.py": "sha256:021034013171d27ff1cfff0f6e8d2a9d2e6aebd32f416693ef692a082509954a",
-    "selftest.py": "sha256:ef41f284274d793499af530cb9fc68f86e5fab34e17dbcb2b88b558118e28ff4"
+    "selftest.py": "sha256:ef41f284274d793499af530cb9fc68f86e5fab34e17dbcb2b88b558118e28ff4",
+    "README.md": "sha256:e97d040120887d6da6499663436007c50adbaf42d45aface047b77e44b732e4f"
   }
 }

--- a/conformance/revocation/README.md
+++ b/conformance/revocation/README.md
@@ -1,0 +1,115 @@
+# Revocation conformance vectors
+
+Nine vectors covering what an enforcement point must do when an authorization was
+valid when it was written and has since been withdrawn. Six are refusals, three are
+positive controls, and all nine are scoped to a declared `revocation` capability so
+that an implementation without one reports an unfilled gap instead of a red result.
+
+Everything here is self-contained: the vectors, the schema they validate against, a
+reference adapter that answers them, the runner that scores them, a digest manifest
+that pins them, and a set of negative controls that prove the scoring can fail.
+
+```
+python conformance/revocation/runner.py \
+    --adapter conformance/revocation/revocation_adapter.py
+python conformance/revocation/selftest.py
+```
+
+## Two failure codes
+
+| Code | Verdict | Meaning |
+|---|---|---|
+| `MANDATE_REVOKED` | REJECT | The withdrawal was read and found. The authorization was valid when written and has since been withdrawn by its issuer. |
+| `REVOCATION_UNCHECKABLE` | UNMEASURABLE | The withdrawal state could not be read, or could not be attributed to what is being presented. |
+
+Neither collapses into a staleness code. A mandate revoked inside its freshness bound
+is not old, and reporting it stale sends an operator to look at clocks. That is the
+measured-and-wrong versus could-not-measure distinction applied to a second axis: old
+and withdrawn are as different as wrong and unreadable.
+
+## What the vectors cover
+
+| Vector | What it is |
+|---|---|
+| `neg-cat3-002` | Withdrawn inside the freshness window. A freshness check alone passes this and the layer fails open. |
+| `pos-cat3-002` | Control: registry reachable and clean. A layer that refuses whenever it consults a registry at all is indistinguishable from one that refuses everything. |
+| `neg-cat3-003` | Registry unreachable. Absence of measurement is never a pass, and the code must differ from a measured withdrawal. |
+| `neg-cat3-004` | Registry stale beyond its own declared publication interval. Reading a registry that stopped publishing as clean converts an outage into an allow. |
+| `neg-cat3-005` | Back-dated window. The comparison is made against an authority-signed instant, never one the presenting party controls. |
+| `neg-cat3-006` | Re-issued mandate naming no predecessor. A replacement and a revoked original under a new identifier cannot be told apart. |
+| `pos-cat3-003` | Control: the same re-issue, naming the predecessor. The check is on an unresolvable link, not on the act of replacing a revoked mandate. |
+| `neg-cat3-007` | Revoked, with no authority-signed instant to compare against. Rejecting would be a guess and passing would accept a back-dated claim. |
+| `pos-cat3-004` | Control: the authority-signed instant precedes the withdrawal. A withdrawal ends an authorization going forward and does not unwind what it already authorized. |
+
+The last two exist because mutation testing demanded them. Each mutant in
+`selftest.py` deletes one check from the reference adapter, and two of them survived
+against the first seven vectors: an adapter that trusted a party-asserted time, and
+one that rejected on the presence of an identifier in the revoked list without ever
+measuring the window. Both survived because no vector exercised the branch. A
+surviving mutant is a vector nobody wrote, so the two were written.
+
+## Capability profiles
+
+A vector declares what it needs:
+
+```json
+"requires": ["revocation"]
+```
+
+An implementation declares what it has, either in the adapter as `CAPABILITIES` or on
+the command line as `--profile`. The runner runs the vectors inside the profile and
+reports the rest as out of profile. There is no third state: an adapter that declares
+nothing and is given no profile is a fatal error rather than a silent run of
+everything, because a profile inferred from the vectors would mean every
+implementation claims every capability the suite happens to ship.
+
+The flag is not a way to opt out of being measured. A capability inside the profile
+that no positive control exercises fails the suite outright, which means declaring
+`revocation` obliges you to pass the must-pass vectors and not only to refuse the
+must-reject ones.
+
+## The adapter contract
+
+```python
+CAPABILITIES = ["revocation"]
+
+def evaluate(question) -> {"verdict": "PASS|REJECT|UNMEASURABLE",
+                           "code": str | None,
+                           "reason": str,
+                           "entry_point": str}
+```
+
+The adapter is handed the vector's `id`, `category` and `input`. It is not handed
+`expected` or `positive_control`. Those stay with the runner, so an adapter that
+would derive its answer from the expected verdict has nothing to derive it from, and
+that entire family of tautological adapters stops being detectable-in-principle and
+starts being impossible. This is the cheapest structural property in the suite and it
+subsumes every heuristic aimed at the same problem.
+
+`entry_point` names the production path the answer came through. The runner compares
+it for equality and never parses or interprets it, because an adapter names its own
+entry points and a runner that recognises particular names holds an opinion about
+adapter internals and stops working for the next implementer. The predicate is
+sameness of path, not identity of path. Be precise about what that buys: it catches
+an adapter answering the must-pass inputs from one path and the must-reject inputs
+from another, and it cannot catch one that names a path it never called. An absent or
+blank value is a refusal rather than a pass, because empty equals empty and the check
+would otherwise hold vacuously in exactly the case it exists to fire on.
+
+## Negative controls
+
+`selftest.py` is the reason to believe any of the above. It runs fifteen cases: one
+that must pass, five fake adapters that must be refused, seven single-line mutants of
+the reference adapter that must be killed, a capability declared with no positive
+control, and a vector file edited away from its pinned digest.
+
+A suite only ever run against an implementation that passes it has not been shown to
+discriminate, and a gate that has never been observed to fail is indistinguishable
+from one that is not running.
+
+## Pinning
+
+`MANIFEST.json` carries a SHA-256 for every file here, and the runner refuses a vector
+file whose digest does not match. A suite that can be edited between publication and
+use proves nothing about the implementation that ran it. Regenerate the manifest
+deliberately, in the same commit as the change it covers.

--- a/conformance/revocation/revocation_adapter.py
+++ b/conformance/revocation/revocation_adapter.py
@@ -1,0 +1,128 @@
+"""Reference adapter for the revocation vectors.
+
+Ships with the vectors because a vector nobody can execute end-to-end is a promise. It
+answers the revocation path and nothing else, and it declares that in CAPABILITIES so the
+runner knows which vectors it is claiming to be measured on.
+
+It reads the action, the authorization and the state, and never the expected verdict. The
+runner does not hand it one.
+
+Two failure codes are added, and neither collapses into one already enumerated:
+
+  MANDATE_REVOKED         REJECT        the withdrawal was read and found
+  REVOCATION_UNCHECKABLE  UNMEASURABLE  the withdrawal state could not be read
+
+STALE_DECISION cannot carry either. A revoked mandate inside its freshness bound is not
+old, and reporting it stale sends an operator to look at clocks. This is the suite's own
+rule 1 applied to a second axis: measured-and-wrong and could-not-measure stay apart.
+"""
+
+from datetime import datetime
+
+REVOKED = "MANDATE_REVOKED"
+UNCHECKABLE = "REVOCATION_UNCHECKABLE"
+
+# What this implementation claims to enforce. The runner runs the vectors requiring these
+# and reports the rest as out of profile, so a capability this adapter does not have stays
+# an unfilled gap rather than a red result, and a capability it does claim must carry a
+# positive control or the suite refuses.
+CAPABILITIES = ["revocation"]
+
+# The entry point every answer below dispatched through. The runner compares it for
+# equality and never parses it. Note what that can and cannot do: it detects an adapter
+# answering the must-pass inputs from a different path than the must-reject ones, and it
+# cannot detect one naming a path it never called.
+ENTRY_POINT = "revocation_adapter.decide"
+
+
+def _instant(text):
+    return datetime.fromisoformat(text.replace("Z", "+00:00"))
+
+
+def evaluate_revocation(vector):
+    """Return a verdict dict, or None when this vector says nothing about revocation."""
+    inp = vector["input"]
+    auth, state = inp.get("authorization", {}), inp.get("state", {})
+    registry = state.get("revocation_registry")
+    if registry is None:
+        return None
+
+    def reject(reason):
+        return {
+            "verdict": "REJECT",
+            "code": REVOKED,
+            "reason": reason,
+            "entry_point": ENTRY_POINT,
+        }
+
+    def unmeasurable(reason):
+        return {
+            "verdict": "UNMEASURABLE",
+            "code": UNCHECKABLE,
+            "reason": reason,
+            "entry_point": ENTRY_POINT,
+        }
+
+    # Reachability first: an unread registry is never a clean registry.
+    if not registry.get("reachable"):
+        return unmeasurable(
+            "revocation state could not be read; absence of measurement is never a pass"
+        )
+
+    # A registry past its own declared publication interval has stopped answering.
+    interval = registry.get("publication_interval_seconds")
+    if interval is not None and "signed_at" in registry and "now" in state:
+        age = (_instant(state["now"]) - _instant(registry["signed_at"])).total_seconds()
+        if age > interval:
+            return unmeasurable(
+                f"revocation registry last signed {int(age)}s ago, beyond its declared "
+                f"publication interval of {int(interval)}s; the answer could not be measured"
+            )
+
+    revoked = set(registry.get("revoked", []))
+    mandate = auth.get("mandate_id")
+
+    # A superseding mandate must name the predecessor it replaces, or its own revocation
+    # state is unmeasurable: a replacement and a re-labelled original look identical.
+    if auth.get("mandate_seq", 1) > 1 and not auth.get("supersedes"):
+        return unmeasurable(
+            "superseding mandate names no predecessor; a replacement and a re-presented "
+            "revoked original could not be told apart"
+        )
+
+    if mandate in revoked:
+        # The window comparison is made against an authority-signed instant, never against
+        # one the presenting party controls. Back-dating alone would otherwise rehabilitate
+        # every act the revoked mandate ever authorized.
+        acted_at = auth.get("authority_signed_at")
+        revoked_at = registry.get("revoked_at")
+        if acted_at and revoked_at and _instant(acted_at) <= _instant(revoked_at):
+            return None  # authority-signed instant places the act before the withdrawal
+        if revoked_at and not acted_at:
+            return unmeasurable(
+                "revocation carries an instant and the action carries none the authority "
+                "signed; the window could not be measured against a party-asserted time"
+            )
+        if revoked_at:
+            return reject(
+                f"mandate {mandate} was revoked at {revoked_at}; the authority-signed "
+                f"instant for this action is {acted_at}, after the withdrawal"
+            )
+        return reject(f"mandate {mandate} is revoked")
+
+    return None
+
+
+def evaluate(vector):
+    out = evaluate_revocation(vector)
+    if out is not None:
+        return out
+    # code is carried explicitly on a pass. The runner compares code on every vector,
+    # including the positive controls, against expected.get("code"), which is None when the
+    # vector omits the field. An omitted key would answer that comparison by accident.
+    return {
+        "verdict": "PASS",
+        "code": None,
+        "reason": "no withdrawal recorded against this mandate",
+        "entry_point": ENTRY_POINT,
+    }

--- a/conformance/revocation/runner.py
+++ b/conformance/revocation/runner.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Capability-scoped conformance runner for the revocation vectors.
+
+Runs one implementation adapter against a vector suite and refuses on:
+
+  - any verdict, failure-code or reason mismatch, positive controls included;
+  - any category, inside the declared profile, that carries no positive control;
+  - any capability declared in the profile that no positive control exercises;
+  - any adapter answer naming no entry point, or naming an empty one;
+  - any category whose positive controls resolved through a different entry
+    point than its negative vectors.
+
+Two properties are worth stating plainly, because a runner that overstates what
+it checks is worse than one that checks less.
+
+The adapter never sees the answer key. It is handed the vector's id, category
+and input, and nothing else. `expected` and `positive_control` stay with the
+runner. An adapter that derives its answer from the expected verdict therefore
+cannot answer at all, which removes that whole family of tautological adapters
+rather than trying to detect one.
+
+The entry point is compared for equality and never parsed. An adapter names its
+own entry points, so the moment a runner recognises particular names it holds an
+opinion about adapter internals and stops working for the next implementer. The
+predicate is sameness of path, not identity of path. What this catches is an
+adapter answering the must-pass inputs from one path and the must-reject inputs
+from another. What it cannot catch is an adapter naming a path it never called.
+
+Usage:
+    python runner.py --adapter path/to/adapter.py [--profile revocation]
+                     [--vectors vectors/revocation_vectors.json]
+"""
+import argparse
+import hashlib
+import importlib.util
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+HERE = Path(__file__).parent
+MANIFEST = HERE / "MANIFEST.json"
+
+EXIT_OK = 0
+EXIT_FAILURES = 1
+EXIT_SUITE_INVALID = 2
+
+
+def load_adapter(path: Path):
+    # An adapter spanning several files must be able to import its siblings.
+    sys.path.insert(0, str(path.resolve().parent))
+    spec = importlib.util.spec_from_file_location("acs_revocation_adapter", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    if not hasattr(mod, "evaluate"):
+        sys.exit(f"FATAL: adapter {path} exposes no evaluate(vector)")
+    return mod
+
+
+def verify_digest(path: Path) -> str | None:
+    """Return a complaint when the file does not match its pinned digest.
+
+    A vector suite that can be edited between publication and use proves nothing
+    about the implementation that ran it. Absent manifest entries are a refusal,
+    never a pass, for the same reason an unread revocation registry is.
+    """
+    if not MANIFEST.exists():
+        return f"no manifest at {MANIFEST}; the suite is unpinned"
+    entries = json.loads(MANIFEST.read_text(encoding="utf-8"))["files"]
+    name = path.resolve().name
+    pinned = entries.get(name)
+    if pinned is None:
+        return f"{name} is not pinned in {MANIFEST.name}"
+    actual = "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+    if actual != pinned:
+        return f"{name} digest {actual} does not match pinned {pinned}"
+    return None
+
+
+def is_positive_control(vector) -> bool:
+    """A declared flag is not a positive control; only an expected PASS is.
+
+    One definition, so that every site deciding which vectors are the controls
+    decides alike. Counting them in one place and bucketing them in another is
+    how a suite ends up certifying a category that holds no must-pass input.
+    """
+    return bool(vector.get("positive_control")) and vector["expected"]["verdict"] == "PASS"
+
+
+def resolve_profile(args, adapter) -> list[str]:
+    """The capabilities an implementation claims to have.
+
+    Given explicitly, or read from the adapter. Never inferred from the vectors:
+    inferring it would mean every implementation declares every capability the
+    suite happens to ship, which is the opposite of what the flag is for.
+    """
+    if args.profile is not None:
+        return [c.strip() for c in args.profile.split(",") if c.strip()]
+    declared = getattr(adapter, "CAPABILITIES", None)
+    if declared is None:
+        sys.exit(
+            "FATAL: adapter declares no CAPABILITIES and no --profile was given. "
+            "An undeclared profile is not an empty one, and guessing it would run "
+            "vectors against a capability the implementation never claimed."
+        )
+    return list(declared)
+
+
+def ask(adapter, vector):
+    """Hand the adapter the question without the answer."""
+    question = {"id": vector["id"], "category": vector["category"], "input": vector["input"]}
+    return adapter.evaluate(question) or {}
+
+
+def check_vector(adapter, vector, entry_points):
+    """Return a complaint string, or None when the vector conforms."""
+    try:
+        out = ask(adapter, vector)
+    except Exception as e:  # an adapter crash is a failure, never a skip
+        return f"adapter raised {type(e).__name__}: {e}"
+
+    ep = out.get("entry_point")
+    if not isinstance(ep, str) or not ep.strip():
+        # Empty equals empty, so an absent value would satisfy the equality check
+        # below while measuring no path at all.
+        return "adapter reported no entry point; the equality check would hold vacuously"
+    entry_points[vector["category"]]["pos" if is_positive_control(vector) else "neg"].add(ep)
+
+    exp = vector["expected"]
+    if out.get("verdict") != exp["verdict"]:
+        return f"verdict {out.get('verdict')!r} != expected {exp['verdict']!r}"
+    if out.get("code") != exp.get("code"):
+        return f"code {out.get('code')!r} != expected {exp.get('code')!r}"
+    reason = (out.get("reason") or "").lower()
+    for needle in exp.get("reason_must_mention", []):
+        if needle.lower() not in reason:
+            return f"reason does not mention {needle!r}: {reason[:120]!r}"
+    return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--adapter", required=True, type=Path)
+    ap.add_argument("--vectors", type=Path, default=HERE / "vectors" / "revocation_vectors.json")
+    ap.add_argument(
+        "--profile",
+        help="comma-separated capabilities this implementation claims; "
+        "defaults to the adapter's CAPABILITIES",
+    )
+    args = ap.parse_args()
+
+    complaint = verify_digest(args.vectors)
+    if complaint:
+        print(f"SUITE INVALID: {complaint}")
+        return EXIT_SUITE_INVALID
+
+    vectors = json.loads(args.vectors.read_text(encoding="utf-8"))["vectors"]
+    adapter = load_adapter(args.adapter)
+    profile = set(resolve_profile(args, adapter))
+
+    in_profile, out_of_profile = [], []
+    for v in vectors:
+        needed = set(v.get("requires", []))
+        (in_profile if needed <= profile else out_of_profile).append(v)
+
+    # A declared capability with no positive control fails loudly. A capability an
+    # implementation does not claim is silent, which is the whole point of the flag:
+    # a declared gap stops being prose and an undeclared one stops being an excuse.
+    uncontrolled = sorted(
+        c
+        for c in profile
+        if not any(c in set(v.get("requires", [])) for v in in_profile if is_positive_control(v))
+    )
+    if uncontrolled:
+        print(f"SUITE INVALID: capabilities declared with no positive control: {uncontrolled}")
+        print("A capability certified only by refusals cannot be told from one that refuses everything.")
+        return EXIT_SUITE_INVALID
+
+    cats = defaultdict(lambda: {"neg": 0, "pos": 0})
+    for v in in_profile:
+        cats[v["category"]]["pos" if is_positive_control(v) else "neg"] += 1
+    missing = [c for c, k in sorted(cats.items()) if k["pos"] == 0]
+    if missing:
+        print(f"SUITE INVALID: categories without a positive control: {missing}")
+        return EXIT_SUITE_INVALID
+
+    failures = []
+    entry_points = defaultdict(lambda: {"pos": set(), "neg": set()})
+    for v in in_profile:
+        complaint = check_vector(adapter, v, entry_points)
+        if complaint:
+            failures.append((v["id"], complaint))
+
+    for c, k in sorted(entry_points.items()):
+        if k["pos"] and k["neg"] and k["pos"] != k["neg"]:
+            failures.append(
+                (
+                    f"cat{c}",
+                    f"positive controls resolved through {sorted(k['pos'])} but negative "
+                    f"vectors through {sorted(k['neg'])}; the gate certified a different "
+                    f"code path than the one negatively tested",
+                )
+            )
+
+    print(
+        f"{len(in_profile) - len(failures)}/{len(in_profile)} vectors conform "
+        f"({sum(k['pos'] for k in cats.values())} positive controls across "
+        f"{len(cats)} categories, profile {sorted(profile)})"
+    )
+    for v in out_of_profile:
+        print(f"  OUT OF PROFILE {v['id']}: requires {sorted(set(v.get('requires', [])) - profile)}")
+    for vid, why in failures:
+        print(f"  FAIL {vid}: {why}")
+    return EXIT_FAILURES if failures else EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conformance/revocation/selftest.py
+++ b/conformance/revocation/selftest.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Negative controls for the runner and the adapter.
+
+A conformance suite that has only ever been run against an implementation that
+passes it has not been shown to discriminate. Everything here is a case the suite
+MUST refuse, plus one case it must accept, so that a green result means the gate
+is live rather than absent. Run it in CI beside the suite itself.
+
+The adapter mutants matter as much as the fake adapters: each one deletes a single
+check from the reference adapter, and the suite has to notice. A mutant that
+survives is a vector nobody wrote.
+
+    python conformance/revocation/selftest.py
+"""
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).parent
+RUNNER = HERE / "runner.py"
+ADAPTER = HERE / "revocation_adapter.py"
+VECTORS = HERE / "vectors" / "revocation_vectors.json"
+
+FAKE_ADAPTERS = {
+    "answer_key": (
+        "# Enforces nothing: it would echo the expected verdict back. The runner never\n"
+        "# hands it one, so it has nothing to echo.\n"
+        "CAPABILITIES = ['revocation']\n"
+        "def evaluate(v):\n"
+        "    e = v['expected']\n"
+        "    return {'verdict': e['verdict'], 'code': e.get('code'),\n"
+        "            'reason': ' '.join(e.get('reason_must_mention', [])),\n"
+        "            'entry_point': 'acme.enforce'}\n"
+    ),
+    "reject_everything": (
+        "CAPABILITIES = ['revocation']\n"
+        "def evaluate(v):\n"
+        "    return {'verdict': 'REJECT', 'code': 'MANDATE_REVOKED',\n"
+        "            'reason': 'revoked', 'entry_point': 'acme.enforce'}\n"
+    ),
+    "no_entry_point": (
+        "CAPABILITIES = ['revocation']\n"
+        "import sys; sys.path.insert(0, r'%s')\n" % HERE.resolve()
+        + "from revocation_adapter import evaluate as _inner\n"
+        "def evaluate(v):\n"
+        "    out = dict(_inner(v)); out.pop('entry_point', None); return out\n"
+    ),
+    "empty_entry_point": (
+        "CAPABILITIES = ['revocation']\n"
+        "import sys; sys.path.insert(0, r'%s')\n" % HERE.resolve()
+        + "from revocation_adapter import evaluate as _inner\n"
+        "def evaluate(v):\n"
+        "    out = dict(_inner(v)); out['entry_point'] = '   '; return out\n"
+    ),
+    "split_path": (
+        "# Answers the must-pass inputs from a second path: a test double wired in\n"
+        "# beside the enforcement layer, which is what the entry-point rule is for.\n"
+        "CAPABILITIES = ['revocation']\n"
+        "import sys; sys.path.insert(0, r'%s')\n" % HERE.resolve()
+        + "from revocation_adapter import evaluate as _inner\n"
+        "def evaluate(v):\n"
+        "    out = dict(_inner(v))\n"
+        "    if out['verdict'] == 'PASS':\n"
+        "        out['entry_point'] = 'test_double.allow'\n"
+        "    return out\n"
+    ),
+}
+
+# Each mutant deletes one check from the reference adapter by rewriting a single
+# line of its source. The suite must go red for every one of them.
+ADAPTER_MUTANTS = {
+    "drop_reachability_check": (
+        r'if not registry\.get\("reachable"\):', 'if False:'),
+    "drop_publication_interval_check": (
+        r'if age > interval:', 'if False:'),
+    "drop_supersession_check": (
+        r'if auth\.get\("mandate_seq", 1\) > 1 and not auth\.get\("supersedes"\):', 'if False:'),
+    "drop_revocation_lookup": (
+        r'if mandate in revoked:', 'if False:'),
+    "trust_party_asserted_time": (
+        r'if revoked_at and not acted_at:', 'if False:'),
+    "ignore_the_window_and_reject_on_the_list": (
+        r'if acted_at and revoked_at and _instant\(acted_at\) <= _instant\(revoked_at\):',
+        'if False:'),
+    "blur_the_reason": (
+        r'return reject\(f"mandate \{mandate\} is revoked"\)', 'return reject("revoked")'),
+}
+
+
+def run(adapter: Path, vectors: Path = VECTORS, profile: str | None = None):
+    cmd = [sys.executable, str(RUNNER), "--adapter", str(adapter), "--vectors", str(vectors)]
+    if profile is not None:
+        cmd += ["--profile", profile]
+    p = subprocess.run(cmd, capture_output=True, text=True)
+    return p.returncode, (p.stdout + p.stderr).strip()
+
+
+def main() -> int:
+    results = []
+
+    def record(name, ok, detail):
+        results.append((name, ok, detail))
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp = Path(tmp)
+
+        # The one case that must pass. Without it a green run proves only that
+        # everything fails, which is the failure this whole file exists to catch.
+        # The expected count is read from the suite rather than written here: a
+        # hardcoded total silently stops matching the moment a vector is added.
+        total = len(json.loads(VECTORS.read_text(encoding="utf-8"))["vectors"])
+        code, out = run(ADAPTER)
+        record(
+            "reference adapter conforms",
+            code == 0 and f"{total}/{total} vectors conform" in out,
+            f"exit {code}: {out}",
+        )
+
+        for name, source in FAKE_ADAPTERS.items():
+            f = tmp / f"{name}.py"
+            f.write_text(source, encoding="utf-8")
+            code, out = run(f)
+            record(f"refuses {name}", code != 0, f"exit {code}: {out}")
+
+        original = ADAPTER.read_text(encoding="utf-8")
+        for name, (pattern, replacement) in ADAPTER_MUTANTS.items():
+            mutated, n = re.subn(pattern, replacement, original, count=1)
+            if n != 1:
+                record(f"mutant {name}", False, "the line this mutant targets is no longer there")
+                continue
+            f = tmp / f"mutant_{name}.py"
+            f.write_text(mutated, encoding="utf-8")
+            code, out = run(f)
+            record(f"kills mutant {name}", code != 0, f"exit {code}: {out}")
+
+        # A capability declared with nothing to certify it must fail loudly, which
+        # is what stops --profile from being a way to opt out of being measured.
+        code, out = run(ADAPTER, profile="revocation,quarantine")
+        record("refuses a capability with no positive control", code == 2, f"exit {code}: {out}")
+
+        # A vector file that does not match its pinned digest is not the suite.
+        tampered = tmp / "vectors"
+        tampered.mkdir()
+        tampered_file = tampered / "revocation_vectors.json"
+        tampered_file.write_text(
+            VECTORS.read_text(encoding="utf-8").replace('"REJECT"', '"PASS"', 1), encoding="utf-8"
+        )
+        code, out = run(ADAPTER, vectors=tampered_file)
+        record("refuses an unpinned vector file", code == 2, f"exit {code}: {out}")
+
+    for name, ok, detail in results:
+        print(f"{'ok  ' if ok else 'FAIL'} {name}")
+        if not ok:
+            print(f"       {detail}")
+    failed = [n for n, ok, _ in results if not ok]
+    print(f"\n{len(results) - len(failed)}/{len(results)} negative controls held")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conformance/revocation/vector.schema.json
+++ b/conformance/revocation/vector.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/GenAI-Security-Project/agent-control-standard/conformance/revocation/vector.schema.json",
+  "title": "Capability-scoped enforcement conformance vector",
+  "description": "One input, the verdict expected of it, and the capabilities an implementation must claim before the vector applies to it. A vector describes behaviour under test and never an implementation, so nothing here names an adapter, an entry point or a code path.",
+  "type": "object",
+  "required": ["id", "category", "requires", "input", "expected"],
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^(neg|pos)-cat[0-9]+-[0-9]+$"
+    },
+    "category": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "requires": {
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": { "type": "string", "minLength": 1 },
+      "description": "Capabilities an implementation must declare in its profile before this vector is run against it. A vector outside the profile is reported and skipped; a capability inside it with no positive control fails the suite."
+    },
+    "description": { "type": "string", "minLength": 1 },
+    "input": {
+      "type": "object",
+      "description": "The action, the authorization presented for it, and the state the enforcement point can consult.",
+      "required": ["action"],
+      "properties": {
+        "action": { "type": "object" },
+        "authorization": { "type": "object" },
+        "state": { "type": "object" }
+      }
+    },
+    "expected": {
+      "type": "object",
+      "required": ["verdict"],
+      "additionalProperties": false,
+      "properties": {
+        "verdict": { "enum": ["PASS", "REJECT", "UNMEASURABLE"] },
+        "code": { "type": ["string", "null"] },
+        "reason_must_mention": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "description": "Substrings the reason must contain. A right verdict for a wrong reason is a latent bug."
+        }
+      }
+    },
+    "positive_control": {
+      "type": "boolean",
+      "description": "Declares intent only. A vector counts as a positive control when this is true AND expected.verdict is PASS, so a must-reject vector carrying the flag can never satisfy the structural gate."
+    }
+  }
+}

--- a/conformance/revocation/vectors/revocation_vectors.json
+++ b/conformance/revocation/vectors/revocation_vectors.json
@@ -1,0 +1,407 @@
+{
+  "$schema": "../vector.schema.json",
+  "suite": "enforcement-negative-revocation-v0",
+  "vectors": [
+    {
+      "id": "neg-cat3-002",
+      "category": 3,
+      "requires": [
+        "revocation"
+      ],
+      "description": "Withdrawn inside the freshness window: the mandate was genuine when written, is well inside its freshness bound, and was revoked by its issuing authority before the act. Nothing about its age disqualifies it, so a freshness check alone passes this and the layer fails open.",
+      "input": {
+        "action": {
+          "type": "commit_funds",
+          "target": "auction-60",
+          "amount": "1000",
+          "actor": "agent-A"
+        },
+        "authorization": {
+          "signature": "VALID",
+          "signer": "agent-A",
+          "mandate_id": "mandate-31",
+          "decision_written_at": "2026-08-19T09:00:00Z",
+          "freshness_bound_seconds": 900
+        },
+        "state": {
+          "now": "2026-08-19T09:03:00Z",
+          "revocation_registry": {
+            "reachable": true,
+            "signed_at": "2026-08-19T09:02:00Z",
+            "revoked": [
+              "mandate-31"
+            ]
+          },
+          "auction-60": {
+            "open": true,
+            "settled": false
+          }
+        }
+      },
+      "expected": {
+        "verdict": "REJECT",
+        "code": "MANDATE_REVOKED",
+        "reason_must_mention": [
+          "revoked",
+          "mandate-31"
+        ]
+      },
+      "positive_control": false
+    },
+    {
+      "id": "pos-cat3-002",
+      "category": 3,
+      "requires": [
+        "revocation"
+      ],
+      "description": "POSITIVE CONTROL. Identical to neg-cat3-002 except the registry is reachable and does not list this mandate. MUST pass: a layer that refuses whenever it consults a revocation registry at all is indistinguishable from one that refuses everything, and the negative vectors beside this one cannot tell the two apart without it.",
+      "input": {
+        "action": {
+          "type": "commit_funds",
+          "target": "auction-60",
+          "amount": "1000",
+          "actor": "agent-A"
+        },
+        "authorization": {
+          "signature": "VALID",
+          "signer": "agent-A",
+          "mandate_id": "mandate-31",
+          "decision_written_at": "2026-08-19T09:00:00Z",
+          "freshness_bound_seconds": 900
+        },
+        "state": {
+          "now": "2026-08-19T09:03:00Z",
+          "revocation_registry": {
+            "reachable": true,
+            "signed_at": "2026-08-19T09:02:00Z",
+            "revoked": []
+          },
+          "auction-60": {
+            "open": true,
+            "settled": false
+          }
+        }
+      },
+      "expected": {
+        "verdict": "PASS"
+      },
+      "positive_control": true
+    },
+    {
+      "id": "neg-cat3-003",
+      "category": 3,
+      "requires": [
+        "revocation"
+      ],
+      "description": "Revocation registry unreachable: the mandate is fresh and correctly signed, and the state that would say whether it still stands cannot be read at all. Absence of measurement is never a pass, and the code must differ from a measured revocation so operators are not sent hunting for a withdrawal that may not exist.",
+      "input": {
+        "action": {
+          "type": "commit_funds",
+          "target": "auction-61",
+          "amount": "1000",
+          "actor": "agent-A"
+        },
+        "authorization": {
+          "signature": "VALID",
+          "signer": "agent-A",
+          "mandate_id": "mandate-32",
+          "decision_written_at": "2026-08-19T10:00:00Z",
+          "freshness_bound_seconds": 900
+        },
+        "state": {
+          "now": "2026-08-19T10:01:00Z",
+          "revocation_registry": {
+            "reachable": false
+          },
+          "auction-61": {
+            "open": true,
+            "settled": false
+          }
+        }
+      },
+      "expected": {
+        "verdict": "UNMEASURABLE",
+        "code": "REVOCATION_UNCHECKABLE",
+        "reason_must_mention": [
+          "revocation",
+          "could not"
+        ]
+      },
+      "positive_control": false
+    },
+    {
+      "id": "neg-cat3-004",
+      "category": 3,
+      "requires": [
+        "revocation"
+      ],
+      "description": "Revocation registry stale beyond its own declared publication interval: reachable, and last signed by the authority longer ago than the interval the authority itself commits to. A registry that has stopped being published cannot answer whether a withdrawal issued since has been recorded, so reading it as clean converts an outage into an allow.",
+      "input": {
+        "action": {
+          "type": "commit_funds",
+          "target": "auction-62",
+          "amount": "1000",
+          "actor": "agent-A"
+        },
+        "authorization": {
+          "signature": "VALID",
+          "signer": "agent-A",
+          "mandate_id": "mandate-33",
+          "decision_written_at": "2026-08-19T11:00:00Z",
+          "freshness_bound_seconds": 900
+        },
+        "state": {
+          "now": "2026-08-19T11:01:00Z",
+          "revocation_registry": {
+            "reachable": true,
+            "signed_at": "2026-08-19T07:00:00Z",
+            "publication_interval_seconds": 3600,
+            "revoked": []
+          },
+          "auction-62": {
+            "open": true,
+            "settled": false
+          }
+        }
+      },
+      "expected": {
+        "verdict": "UNMEASURABLE",
+        "code": "REVOCATION_UNCHECKABLE",
+        "reason_must_mention": [
+          "revocation",
+          "interval"
+        ]
+      },
+      "positive_control": false
+    },
+    {
+      "id": "neg-cat3-005",
+      "category": 3,
+      "requires": [
+        "revocation"
+      ],
+      "description": "Back-dated revocation window: the authority revoked the signer's key, and the only instant the enforcement point can compare against is one the presenting party controls. Evaluating the window against a party-asserted timestamp rehabilitates, by back-dating alone, every act the revoked key ever authorized. The comparison must be made against an authority-signed instant, and here the authority-signed instant places the act after the revocation.",
+      "input": {
+        "action": {
+          "type": "sign_transaction",
+          "target": "auction-63",
+          "actor": "agent-A",
+          "required_signer": "0xAAAA"
+        },
+        "authorization": {
+          "signature": "VALID",
+          "signer": "agent-A",
+          "mandate_id": "mandate-34",
+          "issued_at_claimed": "2026-08-19T08:00:00Z",
+          "authority_signed_at": "2026-08-19T12:30:00Z",
+          "decision_written_at": "2026-08-19T12:30:00Z",
+          "freshness_bound_seconds": 900
+        },
+        "state": {
+          "now": "2026-08-19T12:31:00Z",
+          "revocation_registry": {
+            "reachable": true,
+            "signed_at": "2026-08-19T12:31:00Z",
+            "revoked": [
+              "mandate-34"
+            ],
+            "revoked_at": "2026-08-19T09:00:00Z"
+          },
+          "auction-63": {
+            "open": true,
+            "settled": false
+          }
+        }
+      },
+      "expected": {
+        "verdict": "REJECT",
+        "code": "MANDATE_REVOKED",
+        "reason_must_mention": [
+          "revoked",
+          "authority"
+        ]
+      },
+      "positive_control": false
+    },
+    {
+      "id": "neg-cat3-006",
+      "category": 3,
+      "requires": [
+        "revocation"
+      ],
+      "description": "Re-issued mandate that names no predecessor: a superseding mandate presented at sequence 2 carrying no reference to the mandate it replaces. Without the link the enforcement point cannot tell a legitimate replacement from the revoked original re-presented under a new identifier, so the revocation state of what is in front of it is not measurable, not merely unsatisfied.",
+      "input": {
+        "action": {
+          "type": "commit_funds",
+          "target": "auction-64",
+          "amount": "1000",
+          "actor": "agent-A"
+        },
+        "authorization": {
+          "signature": "VALID",
+          "signer": "agent-A",
+          "mandate_id": "mandate-35b",
+          "mandate_seq": 2,
+          "decision_written_at": "2026-08-19T13:00:00Z",
+          "freshness_bound_seconds": 900
+        },
+        "state": {
+          "now": "2026-08-19T13:01:00Z",
+          "revocation_registry": {
+            "reachable": true,
+            "signed_at": "2026-08-19T13:01:00Z",
+            "revoked": [
+              "mandate-35a"
+            ]
+          },
+          "auction-64": {
+            "open": true,
+            "settled": false
+          }
+        }
+      },
+      "expected": {
+        "verdict": "UNMEASURABLE",
+        "code": "REVOCATION_UNCHECKABLE",
+        "reason_must_mention": [
+          "predecessor"
+        ]
+      },
+      "positive_control": false
+    },
+    {
+      "id": "pos-cat3-003",
+      "category": 3,
+      "requires": [
+        "revocation"
+      ],
+      "description": "POSITIVE CONTROL. The same re-issued mandate, naming exactly the revoked predecessor it replaces. MUST pass: the check is on an unresolvable supersession link, not on the act of replacing a revoked mandate, and a layer that refuses this refuses recovery from every revocation it ever enforces.",
+      "input": {
+        "action": {
+          "type": "commit_funds",
+          "target": "auction-64",
+          "amount": "1000",
+          "actor": "agent-A"
+        },
+        "authorization": {
+          "signature": "VALID",
+          "signer": "agent-A",
+          "mandate_id": "mandate-35b",
+          "mandate_seq": 2,
+          "supersedes": "mandate-35a",
+          "decision_written_at": "2026-08-19T13:00:00Z",
+          "freshness_bound_seconds": 900
+        },
+        "state": {
+          "now": "2026-08-19T13:01:00Z",
+          "revocation_registry": {
+            "reachable": true,
+            "signed_at": "2026-08-19T13:01:00Z",
+            "revoked": [
+              "mandate-35a"
+            ]
+          },
+          "auction-64": {
+            "open": true,
+            "settled": false
+          }
+        }
+      },
+      "expected": {
+        "verdict": "PASS"
+      },
+      "positive_control": true
+    },
+    {
+      "id": "neg-cat3-007",
+      "category": 3,
+      "requires": [
+        "revocation"
+      ],
+      "description": "Revoked mandate presented with no authority-signed instant: the registry records when the withdrawal took effect, and the only time the action carries is one the presenting party wrote. The window cannot be measured, because the party being checked supplies the side of the comparison that decides the answer. Rejecting it would be a guess and passing it would accept a back-dated claim, so neither verdict is available and the honest answer is that the measurement could not be made.",
+      "input": {
+        "action": {
+          "type": "commit_funds",
+          "target": "auction-65",
+          "amount": "1000",
+          "actor": "agent-A"
+        },
+        "authorization": {
+          "signature": "VALID",
+          "signer": "agent-A",
+          "mandate_id": "mandate-36",
+          "issued_at_claimed": "2026-08-19T14:00:00Z",
+          "decision_written_at": "2026-08-19T14:30:00Z",
+          "freshness_bound_seconds": 900
+        },
+        "state": {
+          "now": "2026-08-19T14:30:00Z",
+          "revocation_registry": {
+            "reachable": true,
+            "signed_at": "2026-08-19T14:31:00Z",
+            "revoked": [
+              "mandate-36"
+            ],
+            "revoked_at": "2026-08-19T14:15:00Z"
+          },
+          "auction-65": {
+            "open": true,
+            "settled": false
+          }
+        }
+      },
+      "expected": {
+        "verdict": "UNMEASURABLE",
+        "code": "REVOCATION_UNCHECKABLE",
+        "reason_must_mention": [
+          "window",
+          "authority"
+        ]
+      },
+      "positive_control": false
+    },
+    {
+      "id": "pos-cat3-004",
+      "category": 3,
+      "requires": [
+        "revocation"
+      ],
+      "description": "POSITIVE CONTROL. The mandate is listed as revoked, and the authority-signed instant for the action precedes the withdrawal. MUST pass: a withdrawal ends an authorization going forward and does not unwind what it already authorized, so a layer that refuses this refuses every act any later-revoked mandate ever covered. Without this control the suite cannot tell an implementation that measures the window from one that rejects on the presence of the identifier in the list.",
+      "input": {
+        "action": {
+          "type": "commit_funds",
+          "target": "auction-66",
+          "amount": "1000",
+          "actor": "agent-A"
+        },
+        "authorization": {
+          "signature": "VALID",
+          "signer": "agent-A",
+          "mandate_id": "mandate-37",
+          "authority_signed_at": "2026-08-19T15:00:00Z",
+          "decision_written_at": "2026-08-19T15:30:00Z",
+          "freshness_bound_seconds": 900
+        },
+        "state": {
+          "now": "2026-08-19T15:30:00Z",
+          "revocation_registry": {
+            "reachable": true,
+            "signed_at": "2026-08-19T15:31:00Z",
+            "revoked": [
+              "mandate-37"
+            ],
+            "revoked_at": "2026-08-19T15:20:00Z"
+          },
+          "auction-66": {
+            "open": true,
+            "settled": false
+          }
+        }
+      },
+      "expected": {
+        "verdict": "PASS"
+      },
+      "positive_control": true
+    }
+  ]
+}


### PR DESCRIPTION
## What changed

This is the separate pull request I promised in #30. It adds revocation conformance vectors for category 3, with a reference adapter that answers them. It also adds a runner that scopes vectors to a declared capability, and negative controls that show the scoring can fail.

Everything lands under `conformance/revocation/`. It shares no file with #30. The two are reviewable independently and can land in either order.

#30 declared the revocation half of category 3 an open gap. It asked for contributions from implementations that exercise revocation. This is that contribution. I have deliberately not touched anything #30 already claims.

## Type of change

Tooling and CI. Nothing under specification/ or docs/spec/ is touched, and no schema, hook, event or AgBOM definition changes.

The two failure codes below live in the new directory's README as a proposed enumeration, the way #30 handles its own. Moving either into normative text is a maintainers' call, and this pull request does not ask for it.

## What is here

Nine vectors: six refusals and three positive controls. They cover withdrawal inside the freshness window, an unreachable registry, and a registry stale past its own declared publication interval. They also cover a back-dated revocation window, a re-issued mandate naming no predecessor, and a revoked mandate with no authority-signed instant to measure against.

Two failure codes. `MANDATE_REVOKED` is a withdrawal that was read and found. `REVOCATION_UNCHECKABLE` is a withdrawal state that could not be read. Neither collapses into a staleness code. A mandate revoked inside its freshness bound is not old, and calling it stale sends an operator to look at clocks. That is the measured-and-wrong versus could-not-measure rule, applied to a second axis.

A capability mechanism, which answers the integration question I raised on #30. Each vector declares what it needs with `requires`. Each implementation declares what it has, either as `CAPABILITIES` in the adapter or as `--profile` on the command line. The runner runs the intersection and reports the rest as out of profile. An implementation with no revocation mechanism gets an unfilled gap rather than a red result.

The flag is not a way to opt out of being measured. A capability inside the profile that no positive control exercises fails the suite outright. Declaring revocation therefore obliges you to pass the must-pass vectors, not only to refuse the must-reject ones. There is no third state either. An adapter that declares nothing, given no profile, is a fatal error rather than a silent run of everything.

## Seven vectors became nine, and the reason is the interesting part

I described seven vectors in my review. There are nine here.

`selftest.py` mutates the reference adapter, one deleted check per mutant, and requires the suite to notice each one. Two mutants survived against the original seven. One trusted a timestamp the presenting party controls. The other rejected on the presence of an identifier in the revoked list, without ever measuring the withdrawal window.

That second one is a real bug in the fail-closed direction. It refuses every act a later-revoked mandate ever authorized, which breaks recovery.

Both survived because no vector exercised the branch. A surviving mutant is a vector nobody wrote, so I wrote the two. `pos-cat3-004` is the control that separates an implementation measuring the window from one rejecting on list membership. I would rather report that the count moved than quietly ship the number I announced.

## What the entry-point requirement does, and what it does not

Your entry-point fix is the right mechanism and I kept it. Both constraints from my last comment are in. The runner compares the reported value for equality and never parses it. A blank or absent value is a refusal rather than a pass. Empty equals empty, so the check would otherwise hold vacuously in the case it exists to fire on.

It does not close the answer-key hole. I said I would settle that with a run rather than by reading the diff, so here it is, against your branch at `459ec820`:

```
$ python conformance/negative/runner.py --adapter conformance/negative/reference_adapter.py
18/18 vectors conform (6 positive controls across 6 categories)     exit 0

$ python conformance/negative/runner.py --adapter answer_key.py
18/18 vectors conform (6 positive controls across 6 categories)     exit 0
```

Here is the whole of the second adapter, which enforces nothing:

```python
def evaluate(vector):
    e = vector["expected"]
    return {"verdict": e["verdict"], "code": e.get("code"),
            "reason": " ".join(e.get("reason_must_mention", [])),
            "entry_point": "acme.enforcement.decide"}
```

The output is byte for byte the reference adapter's. That is the same result as before the fix, because a self-reported name compared only against itself costs one line to satisfy.

The cheap structural answer is to stop handing the adapter the answer. My runner passes the vector identifier, its category and its input, and keeps the expected verdict and the control flag to itself:

```python
question = {"id": v["id"], "category": v["category"], "input": v["input"]}
out = adapter.evaluate(question) or {}
```

An adapter that would derive its verdict from the expected one then has nothing to derive it from. The whole family stops being something to detect and becomes something that cannot be expressed. That is why my runner is a separate file rather than a patch to yours. Folding the same change into `conformance/negative/runner.py` is yours to make whenever #30 is otherwise settled.

One smaller thing, and it is a review note rather than a request. `b3ef6a13` fixed the positive-control predicate where the structural gate counts. The entry-point bucketing a few lines below still reads the declared flag directly. A must-reject vector carrying that flag is therefore refused a place in the count, and still lands in the positive bucket for the entry-point comparison. Deciding it once, in one function both sites call, is what I did here.

## Verification

```
$ python conformance/revocation/runner.py --adapter conformance/revocation/revocation_adapter.py
9/9 vectors conform (3 positive controls across 1 categories, profile ['revocation'])

$ python conformance/revocation/selftest.py
15/15 negative controls held
```

The fifteen are one implementation that must pass and five fake adapters that must be refused. Then seven single-line mutants of the reference adapter that must be killed. Then a capability declared with no positive control, and a vector file edited away from its pinned digest.

A gate nobody has watched fail is indistinguishable from one that is not running. So the suite ships with evidence that it discriminates, rather than the assertion.

`MANIFEST.json` carries a SHA-256 for every file in the directory. The runner refuses a vector file whose digest does not match. A suite editable between publication and use proves nothing about the implementation that ran it.

CI runs all of it on any change under the new directory. It also validates the vectors against their schema and checks that every file still matches its pinned digest. The workflow is path-scoped, so it stays green independently of anything else in the repository.

## Checklist

- [x] Commits are signed off, as the DCO requires.
- [x] Prose follows STYLE.md.
- [x] No secrets, tokens, or internal URLs in the diff.
- [ ] The strict mkdocs build passes.

On the last one: nothing here is under docs/ or in the mkdocs config, so the site build takes no input from this change. Say the word if you want the directory in the docs tree, and I will wire it up and run the build.

## Security

This change has no security impact. It adds test vectors, a reference adapter, and a runner. Nothing here executes against a live system, and nothing changes what an implementation does in production.
