### PR TITLE
Move the schema namespace onto a project-controlled base URI

### DIFF
--- a/specification/ACS/acs_schema.json
+++ b/specification/ACS/acs_schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://agentcontrolstandard.org/schema/v0.1.0/acs_schema.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/acs_schema.json",
   "title": "ACS Schema (v0.1.0 aggregator)",
-  "description": "Aggregator manifest for the modular ACS v0.1.0 JSON Schema package. Each subschema lives as its own file under specification/v0.1.0/ and carries an $id under https://acs.org/schema/v0.1.0/...; this file lists the package contents and cross-references them via relative $ref so a single document can be loaded as the entry point. Validators that need a self-contained bundle should resolve $ref by loading the referenced files; validators that follow $id can ignore this aggregator and load the modular files directly.",
+  "description": "Aggregator manifest for the modular ACS v0.1.0 JSON Schema package. Each subschema lives as its own file under specification/v0.1.0/ and carries an $id under https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/...; this file lists the package contents and cross-references them via relative $ref so a single document can be loaded as the entry point. Validators that need a self-contained bundle should resolve $ref by loading the referenced files; validators that follow $id can ignore this aggregator and load the modular files directly.",
   "version": "0.1.0",
 
   "$defs": {

--- a/specification/v0.1.0/agbom/component.json
+++ b/specification/v0.1.0/agbom/component.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/agbom/component.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/agbom/component.json",
   "title": "ACS AgBOM Component",
   "description": "Single component in an Agent Bill of Materials. Discriminated by 'type'. Every component carries provenance of its registration so AgBOM mutations are traceable in the same lineage system as data flow.",
   "type": "object",

--- a/specification/v0.1.0/agbom/document.json
+++ b/specification/v0.1.0/agbom/document.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/agbom/document.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/agbom/document.json",
   "title": "ACS AgBOM Document",
   "description": "Canonical AgBOM document. Wire-shape for the Inspect pillar. Serializations to CycloneDX 1.6, SPDX 3.0, and SWID are deterministic derivations from this canonical form (see inspect/format-mapping.json). The Observed Agent always emits this canonical form on the wire; the Guardian renders serializations on request from downstream consumers.",
   "type": "object",

--- a/specification/v0.1.0/ask-details.json
+++ b/specification/v0.1.0/ask-details.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/ask-details.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/ask-details.json",
   "title": "ACS ASK Details",
   "description": "Approver descriptor and prompt details. Required when decision is 'ask'.",
   "type": "object",

--- a/specification/v0.1.0/context-entry.json
+++ b/specification/v0.1.0/context-entry.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/context-entry.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/context-entry.json",
   "title": "ACS ContextEntry",
   "description": "Append-only entry in a SessionContext's audit chain. Maintained server-side by the Guardian; not transmitted in full on the wire (the wire-visible commitment is chain_hash inside the request envelope's metadata.session_state). Defined here so that hash-chain verification is portable across implementations: any conformant Guardian MUST produce the same entry_hash for the same step content under the rules below, otherwise cross-implementation audit comparison and chain-mismatch detection break. Storage representation is implementation-defined (in-memory, append-only log, SQL row, etc.); this schema constrains the canonical form used for hashing and audit export, not how Guardians store the data internally.",
   "type": "object",

--- a/specification/v0.1.0/defer-details.json
+++ b/specification/v0.1.0/defer-details.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/defer-details.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/defer-details.json",
   "title": "ACS DEFER Details",
   "description": "Deferral metadata when the Guardian could not reach a verdict. Required when decision is 'defer'.",
   "type": "object",

--- a/specification/v0.1.0/handshake.json
+++ b/specification/v0.1.0/handshake.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/handshake.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/handshake.json",
   "title": "ACS Handshake",
   "description": "Capability negotiation messages exchanged at session start, before any hook traffic. The Observed Agent sends a ClientHello; the Guardian Agent responds with a ServerHello. Version mismatch terminates with an UNSUPPORTED_VERSION error in the JSON-RPC error envelope. Unknown fields MUST be ignored at every level. This file defines both message shapes via $defs; the wire encoding wraps them in the standard request/response envelope using method 'handshake/hello'.",
   "type": "object",

--- a/specification/v0.1.0/hooks/agbom-changed.json
+++ b/specification/v0.1.0/hooks/agbom-changed.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/hooks/agbom-changed.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/hooks/agbom-changed.json",
   "title": "agbom/changed payload",
   "description": "AgBOM mutation notification. Emitted by the Observed Agent whenever a component is added, removed, or version-changed mid-session. MAY be denied by the Guardian to block a hot-swap (e.g., refuse a model upgrade mid-session); otherwise audited. MUST be written into the SessionContext audit chain alongside the originating mutation.",
   "type": "object",

--- a/specification/v0.1.0/hooks/agbom-snapshot.json
+++ b/specification/v0.1.0/hooks/agbom-snapshot.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/hooks/agbom-snapshot.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/hooks/agbom-snapshot.json",
   "title": "agbom/snapshot payload",
   "description": "Full Agent Bill of Materials snapshot. Emitted by the Observed Agent once per session, after sessionStart and before any content-bearing hook fires; also re-emitted after any handshake renegotiation. Disposition is normally 'allow'; Guardians MAY return 'deny' to refuse a session whose component graph contains a banned model, tool, peer, or knowledge source. agbom/snapshot MUST be written into the SessionContext audit chain (the AgBOM is part of the session's security-relevant history).",
   "type": "object",

--- a/specification/v0.1.0/hooks/agent-response.acs-provenance.json
+++ b/specification/v0.1.0/hooks/agent-response.acs-provenance.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/hooks/agent-response.acs-provenance.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/hooks/agent-response.acs-provenance.json",
   "title": "steps/agentResponse payload (ACS-Provenance profile)",
   "description": "Strict variant of agent-response.json for deployments running provenance_producer: deterministic / claiming ACS-Provenance. Every content item MUST carry provenance. ACS-Core deployments validate against the base schema instead.",
   "allOf": [{ "$ref": "./agent-response.json" }],

--- a/specification/v0.1.0/hooks/agent-response.json
+++ b/specification/v0.1.0/hooks/agent-response.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/hooks/agent-response.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/hooks/agent-response.json",
   "title": "steps/agentResponse payload",
   "description": "Payload for the agentResponse hook. Fires when the agent's response is ready, before reaching the user.",
   "type": "object",

--- a/specification/v0.1.0/hooks/agent-trigger.json
+++ b/specification/v0.1.0/hooks/agent-trigger.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/hooks/agent-trigger.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/hooks/agent-trigger.json",
   "title": "steps/agentTrigger payload",
   "description": "Payload for the agentTrigger hook. Fires when an agent is activated.",
   "type": "object",

--- a/specification/v0.1.0/hooks/knowledge-retrieval.acs-provenance.json
+++ b/specification/v0.1.0/hooks/knowledge-retrieval.acs-provenance.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/hooks/knowledge-retrieval.acs-provenance.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/hooks/knowledge-retrieval.acs-provenance.json",
   "title": "steps/knowledgeRetrieval payload (ACS-Provenance profile)",
   "description": "Strict variant of knowledge-retrieval.json for deployments running provenance_producer: deterministic / claiming ACS-Provenance. The query and every result MUST carry provenance. ACS-Core deployments validate against the base schema instead.",
   "allOf": [{ "$ref": "./knowledge-retrieval.json" }],

--- a/specification/v0.1.0/hooks/knowledge-retrieval.json
+++ b/specification/v0.1.0/hooks/knowledge-retrieval.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/hooks/knowledge-retrieval.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/hooks/knowledge-retrieval.json",
   "title": "steps/knowledgeRetrieval payload",
   "description": "Payload for the knowledgeRetrieval hook. Fires when the agent retrieves knowledge (RAG, vector DB, etc.).",
   "type": "object",

--- a/specification/v0.1.0/hooks/memory-context-retrieval.acs-provenance.json
+++ b/specification/v0.1.0/hooks/memory-context-retrieval.acs-provenance.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/hooks/memory-context-retrieval.acs-provenance.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/hooks/memory-context-retrieval.acs-provenance.json",
   "title": "steps/memoryContextRetrieval payload (ACS-Provenance profile)",
   "description": "Strict variant of memory-context-retrieval.json for deployments running provenance_producer: deterministic / claiming ACS-Provenance. Every result MUST carry provenance. ACS-Core deployments validate against the base schema instead.",
   "allOf": [{ "$ref": "./memory-context-retrieval.json" }],

--- a/specification/v0.1.0/hooks/memory-context-retrieval.json
+++ b/specification/v0.1.0/hooks/memory-context-retrieval.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/hooks/memory-context-retrieval.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/hooks/memory-context-retrieval.json",
   "title": "steps/memoryContextRetrieval payload",
   "description": "Payload for the memoryContextRetrieval hook. Fires when the agent reads from persistent memory.",
   "type": "object",

--- a/specification/v0.1.0/hooks/memory-store.acs-provenance.json
+++ b/specification/v0.1.0/hooks/memory-store.acs-provenance.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/hooks/memory-store.acs-provenance.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/hooks/memory-store.acs-provenance.json",
   "title": "steps/memoryStore payload (ACS-Provenance profile)",
   "description": "Strict variant of memory-store.json for deployments running provenance_producer: deterministic / claiming ACS-Provenance. The written content MUST carry provenance. ACS-Core deployments validate against the base schema instead.",
   "allOf": [{ "$ref": "./memory-store.json" }],

--- a/specification/v0.1.0/hooks/memory-store.json
+++ b/specification/v0.1.0/hooks/memory-store.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/hooks/memory-store.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/hooks/memory-store.json",
   "title": "steps/memoryStore payload",
   "description": "Payload for the memoryStore hook. Fires before the agent writes to persistent memory.",
   "type": "object",

--- a/specification/v0.1.0/hooks/post-compact.json
+++ b/specification/v0.1.0/hooks/post-compact.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/hooks/post-compact.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/hooks/post-compact.json",
   "title": "steps/postCompact payload",
   "description": "Fires after compaction has occurred. The hook is audit + provenance-binding: the Guardian records the new summary's content and lineage, and MAY return 'modify' to rewrite or further redact the summary, but MUST NOT return 'deny' — compaction has already happened and the audit chain MUST record the post-compact state. Provenance on the summary is normative on origin and derived_from: origin MUST be 'agent_generated', and derived_from MUST equal the union of provenance_ids of every entry in entries_compacted. The framework — not the LLM — populates derived_from. The Guardian projects this lineage onto its own trust classification in policy (v0.1 does not carry a trust field on the wire — see §7.1); the integrity property the Guardian MUST enforce is the standard monotonicity rule, namely that the summary's effective trust cannot exceed the minimum effective trust of its derived_from entries. No amount of LLM processing launders untrusted-classified data into trusted-classified data.",
   "type": "object",

--- a/specification/v0.1.0/hooks/pre-compact.json
+++ b/specification/v0.1.0/hooks/pre-compact.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/hooks/pre-compact.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/hooks/pre-compact.json",
   "title": "steps/preCompact payload",
   "description": "Fires before the runtime LLM compresses its context window into a summary. Decision-eligible — Guardians MAY return 'deny' to block compaction (e.g., because deployment policy forbids compacting after data the Guardian classifies as untrusted has entered until a re-grounding from a policy-trusted origin occurs). Compaction is the chokepoint where provenance can be laundered: the summary that comes out is new agent_generated content whose lineage spans every entry in the pre-compaction context. Without this hook, AARM cumulative-context tracking breaks across compaction, FIDES's monotonicity claim is unverifiable, and 'don't compact across a trust boundary' policies have nowhere to attach. (Trust classification is computed by the Guardian against local policy in v0.1 — see §7.1.)",
   "type": "object",

--- a/specification/v0.1.0/hooks/session-end.json
+++ b/specification/v0.1.0/hooks/session-end.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/hooks/session-end.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/hooks/session-end.json",
   "title": "steps/sessionEnd payload",
   "description": "Payload for the sessionEnd hook. Fires when the session terminates. Asynchronous; does not block agent.",
   "type": "object",

--- a/specification/v0.1.0/hooks/session-start.json
+++ b/specification/v0.1.0/hooks/session-start.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/hooks/session-start.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/hooks/session-start.json",
   "title": "steps/sessionStart payload",
   "description": "Fires once at session initiation, before any other steps/* hook for the session_id. Establishes the session boundary, opens the receipt chain (the first ContextEntry has previous_hash=null), and lets Guardians attach session-level state (policy bundle selection, tenant routing, identity binding) before content-bearing hooks fire. All payload fields are OPTIONAL — the simplest valid invocation is an empty payload that just marks the session boundary. Required by paradigms that need an explicit session boundary marker (AARM cumulative-context, IBAC intent lock at session start) and recommended for any deployment that wants to attach session-level identity or policy state out-of-band from agentTrigger.",
   "type": "object",

--- a/specification/v0.1.0/hooks/skill-load.json
+++ b/specification/v0.1.0/hooks/skill-load.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/hooks/skill-load.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/hooks/skill-load.json",
   "title": "steps/skillLoad payload",
   "description": "Fires when a registered skill activates into a session, before its actions run. Where steps/skillRegister vets the artifact statically and once, steps/skillLoad governs each activation in live context. It carries the load path so a Guardian can see and contain inter-skill cascades (skill A loads B loads C, each clean alone), and it carries the digest of the artifact being loaded so the Guardian can bind this activation to an approved prior registration. A skillLoad MUST be correlatable to a prior approved steps/skillRegister for the same skill_id and digest. A load the Guardian cannot tie to an approved registration, or whose digest differs from the approved one, is unverifiable and SHOULD be denied. Without this binding the lifecycle gate is bypassable: a framework could emit skillLoad for an artifact that was never registered or whose registration was denied. The Guardian also SHOULD deny when load_path shows a skill loading another skill outside its declared composed_skills.",
   "type": "object",

--- a/specification/v0.1.0/hooks/skill-register.json
+++ b/specification/v0.1.0/hooks/skill-register.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/hooks/skill-register.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/hooks/skill-register.json",
   "title": "steps/skillRegister payload",
   "description": "Fires when a skill enters the agent's available set, before it is eligible to load or run. This is the static vetting gate: the only point where a Guardian inspects the whole skill artifact and fixes its approved integrity digest before any of its actions execute. Per-action hooks like steps/toolCallRequest cannot catch a payload split across a skill's actions, because each action is benign in isolation. The malice exists only in the composition. The approval recorded here is what steps/skillLoad is later checked against, by the (skill_id, digest) pair. A Guardian MAY deny registration; a denied skill MUST NOT become eligible to load. The full definition body travels in this payload for inspection but is NOT persisted to the AgBOM. Only definition.ref and definition.digest persist (Spec Review Principle 3).",
   "type": "object",

--- a/specification/v0.1.0/hooks/skill-unload.json
+++ b/specification/v0.1.0/hooks/skill-unload.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/hooks/skill-unload.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/hooks/skill-unload.json",
   "title": "steps/skillUnload payload",
   "description": "Fires when a skill leaves the active set. Its enforcement value is low: by unload time the skill's actions have already run, so a Guardian typically observes rather than denies. It earns a place for two reasons: it keeps the AgBOM's active inventory accurate, and repeated load/unload churn of the same skill is itself an evasion signal worth tracing. Deployments MAY fold this into agbom/changed instead of emitting a distinct hook; the field shape below is what agbom/changed would carry for a skill removal.",
   "type": "object",

--- a/specification/v0.1.0/hooks/subagent-start.json
+++ b/specification/v0.1.0/hooks/subagent-start.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/hooks/subagent-start.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/hooks/subagent-start.json",
   "title": "steps/subagentStart payload",
   "description": "Fires when a parent agent spawns a subagent in-process — i.e., delegation that does NOT cross an A2A boundary. A2A-mediated delegation flows through steps/agentTrigger with trigger_type='a2a_inbound' on the subagent's side; subagentStart is for the same-runtime case. The audit chain must record whether the subagent inherits the parent's Intent.parsed, gets a derived intent, or starts fresh — and a Guardian MAY deny the spawn if intent_derivation would grant capabilities the parent's Intent.parsed does not authorize. Sessions are per-subagent: each subagent gets its own session_id and SessionContext; the parent–child relation is captured here.",
   "type": "object",

--- a/specification/v0.1.0/hooks/subagent-stop.json
+++ b/specification/v0.1.0/hooks/subagent-stop.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/hooks/subagent-stop.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/hooks/subagent-stop.json",
   "title": "steps/subagentStop payload",
   "description": "Fires when an in-process subagent terminates. The envelope's metadata.session_id is the PARENT's session (the parent receives the subagent-stop notification on its own audit chain); the subagent's own session has by this point already emitted its sessionEnd with its own final_chain_hash. This hook lets the parent's audit chain reference the subagent's terminal state without merging the two chains. Not decision-eligible — the subagent has already terminated.",
   "type": "object",

--- a/specification/v0.1.0/hooks/system-ping.json
+++ b/specification/v0.1.0/hooks/system-ping.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/hooks/system-ping.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/hooks/system-ping.json",
   "title": "system/ping payload",
   "description": "Liveness probe. Carries no enforcement semantics. Guardians MUST always return decision='allow' for system/ping regardless of policy, signature, or session state. system/ping MUST NOT be written into the SessionContext audit chain (no ContextEntry, no chain_hash advance) and MUST NOT require a signature even if the session otherwise mandates them, so liveness probing remains possible during signature-rotation or key-resolution failures. Connection failure or response timeout for system/ping is a transport-level signal — the Observed Agent MAY use it to renegotiate transport, re-handshake, or fail over.",
   "type": "object",

--- a/specification/v0.1.0/hooks/tool-call-request.acs-provenance.json
+++ b/specification/v0.1.0/hooks/tool-call-request.acs-provenance.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/hooks/tool-call-request.acs-provenance.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/hooks/tool-call-request.acs-provenance.json",
   "title": "steps/toolCallRequest payload (ACS-Provenance profile)",
   "description": "Strict variant of tool-call-request.json for deployments running provenance_producer: deterministic / claiming ACS-Provenance. Every argument value MUST carry its own provenance. ACS-Core deployments validate against the base schema instead.",
   "allOf": [{ "$ref": "./tool-call-request.json" }],

--- a/specification/v0.1.0/hooks/tool-call-request.json
+++ b/specification/v0.1.0/hooks/tool-call-request.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/hooks/tool-call-request.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/hooks/tool-call-request.json",
   "title": "steps/toolCallRequest payload",
   "description": "Payload for the toolCallRequest hook. Fires before tool execution. Primary enforcement gate.",
   "type": "object",

--- a/specification/v0.1.0/hooks/tool-call-result.acs-provenance.json
+++ b/specification/v0.1.0/hooks/tool-call-result.acs-provenance.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/hooks/tool-call-result.acs-provenance.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/hooks/tool-call-result.acs-provenance.json",
   "title": "steps/toolCallResult payload (ACS-Provenance profile)",
   "description": "Strict variant of tool-call-result.json for deployments running provenance_producer: deterministic / claiming ACS-Provenance. Every output item MUST carry provenance. ACS-Core deployments validate against the base schema instead.",
   "allOf": [{ "$ref": "./tool-call-result.json" }],

--- a/specification/v0.1.0/hooks/tool-call-result.json
+++ b/specification/v0.1.0/hooks/tool-call-result.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/hooks/tool-call-result.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/hooks/tool-call-result.json",
   "title": "steps/toolCallResult payload",
   "description": "Payload for the toolCallResult hook. Fires after tool execution, before the result reaches the agent. Output redaction gate.",
   "type": "object",

--- a/specification/v0.1.0/hooks/turn-end.json
+++ b/specification/v0.1.0/hooks/turn-end.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/hooks/turn-end.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/hooks/turn-end.json",
   "title": "steps/turnEnd payload",
   "description": "Fires at the end of an agent turn. Audit-only — the turn has already happened, so the Guardian writes a ContextEntry but cannot return 'deny' or 'modify'. The matching turnStart's turn_id is referenced via metadata.turn_id on the envelope (and SHOULD also appear in this payload for self-containment). Closes the per-turn audit window so policies that key on per-turn state (cumulative-taint reset, tool-call counts, etc.) have a clean boundary to compute against.",
   "type": "object",

--- a/specification/v0.1.0/hooks/turn-start.json
+++ b/specification/v0.1.0/hooks/turn-start.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/hooks/turn-start.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/hooks/turn-start.json",
   "title": "steps/turnStart payload",
   "description": "Fires at the beginning of an agent turn. Lightweight — most policies will return 'allow' and use the hook for state transitions in policy. Decision-eligible (a Guardian MAY deny to block the turn from starting, e.g., to enforce a per-turn rate limit or to refuse auto-continuation under certain conditions). The framework MUST set metadata.turn_id on the envelope and propagate that turn_id onto every subsequent per-step ContextEntry until the matching turnEnd. Without an explicit turn boundary, AARM-style 'no consequential action in N turns after taint' has to infer turn breaks from userMessage/agentResponse pairing — an inference that breaks under auto-continuation, planning loops, and multi-step ReAct cycles.",
   "type": "object",

--- a/specification/v0.1.0/hooks/user-message.acs-provenance.json
+++ b/specification/v0.1.0/hooks/user-message.acs-provenance.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/hooks/user-message.acs-provenance.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/hooks/user-message.acs-provenance.json",
   "title": "steps/userMessage payload (ACS-Provenance profile)",
   "description": "Strict variant of user-message.json for deployments running provenance_producer: deterministic / claiming ACS-Provenance. Every content item MUST carry provenance. ACS-Core deployments validate against the base schema instead.",
   "allOf": [{ "$ref": "./user-message.json" }],

--- a/specification/v0.1.0/hooks/user-message.json
+++ b/specification/v0.1.0/hooks/user-message.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/hooks/user-message.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/hooks/user-message.json",
   "title": "steps/userMessage payload",
   "description": "Payload for the userMessage hook. Fires when user input arrives, before LLM ingestion.",
   "type": "object",

--- a/specification/v0.1.0/inspect/format-mapping.json
+++ b/specification/v0.1.0/inspect/format-mapping.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/inspect/format-mapping.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/inspect/format-mapping.json",
   "title": "ACS AgBOM Serialization Format Mapping",
   "description": "Normative mapping from the canonical AgBOM (agbom/document.json) into the three v0.1.0 serialization targets: CycloneDX 1.6, SPDX 3.0, and SWID (ISO/IEC 19770-2). This is a documentation-shaped JSON Schema — its body describes the transformation rules; conformant Guardians MUST be able to render at least one of these on request from a downstream consumer.",
   "type": "object",

--- a/specification/v0.1.0/modifications.json
+++ b/specification/v0.1.0/modifications.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/modifications.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/modifications.json",
   "title": "ACS Modifications",
   "description": "Modifications applied when decision is 'modify'. Two mutually exclusive shapes: wholesale replacement via 'modified_content', or structured edits via 'redactions' and/or 'parameter_overrides'. The two shapes never combine, and structured edits MUST target disjoint paths so the effective payload is order-independent (Specification 6.3). The provenance of values introduced by 'parameter_overrides' is not defined in v0.1.",
   "type": "object",

--- a/specification/v0.1.0/provenance-summary.json
+++ b/specification/v0.1.0/provenance-summary.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/provenance-summary.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/provenance-summary.json",
   "title": "ACS Provenance Summary",
   "description": "Condensed view of provenance facts for cumulative or session-level policy decisions. Computed by Guardian framework code from the Provenance objects observed at a step (entry-level summary) or across the session to date (session-level summary). All fields are OPTIONAL — Guardians populate the fields their policies actually consume. Used by paradigms that reason over accumulated context (AARM cumulative-context, FIDES session-level integrity); paradigms that don't (e.g., pure IBAC) can omit the entire object. v0.1 summaries carry origin-derived aggregates only; trust-derived aggregates (e.g., lowest_trust, earliest_untrusted_step_id) are Guardian-internal in v0.1 because trust classification is computed in policy from origin/source_id, not carried on the wire (§7.1).",
   "type": "object",

--- a/specification/v0.1.0/provenance.json
+++ b/specification/v0.1.0/provenance.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/provenance.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/provenance.json",
   "title": "ACS Provenance",
   "description": "Factual lineage label attached to data-bearing fields. Populated by deterministic framework code at channel boundaries, never by the LLM. Provenance attachment is OPTIONAL at the field level; when a Provenance object is emitted, all required fields below MUST be populated. v0.1 carries factual provenance (origin, source_id, derived_from) on the wire; trust classification is performed by the Guardian against local policy keyed on origin and source_id, and is not a v0.1 schema field. The spec (§7.1) reserves an OPTIONAL `trust` enum for vendor implementations that elect to carry classification on the wire; such implementations extend this schema rather than rely on v0.1 to validate the field.",
   "type": "object",

--- a/specification/v0.1.0/request-envelope.json
+++ b/specification/v0.1.0/request-envelope.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/request-envelope.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/request-envelope.json",
   "title": "ACS Request Envelope",
   "description": "JSON-RPC 2.0 envelope with ACS extensions. Sent by the Observed Agent to the Guardian Agent.",
   "type": "object",

--- a/specification/v0.1.0/response-envelope.json
+++ b/specification/v0.1.0/response-envelope.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/response-envelope.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/response-envelope.json",
   "title": "ACS Response Envelope",
   "description": "JSON-RPC 2.0 response envelope with ACS extensions. Sent by the Guardian Agent to the Observed Agent.",
   "type": "object",

--- a/specification/v0.1.0/trace/ocsf-mapping.json
+++ b/specification/v0.1.0/trace/ocsf-mapping.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/trace/ocsf-mapping.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/trace/ocsf-mapping.json",
   "title": "ACS Trace → OCSF event-class mapping",
   "description": "Normative mapping from ACS hooks and decisions to OCSF (Open Cybersecurity Schema Framework) event classes. v0.1.0 conformance requires that a deployment emitting OCSF for the Trace pillar uses these class UIDs and severity rules verbatim. OCSF classes are referenced by their stable class_uid as of OCSF 1.5+.",
   "type": "object",

--- a/specification/v0.1.0/trace/otel-mapping.json
+++ b/specification/v0.1.0/trace/otel-mapping.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://acs.org/schema/v0.1.0/trace/otel-mapping.json",
+  "$id": "https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/trace/otel-mapping.json",
   "title": "ACS Trace → OpenTelemetry semconv mapping",
   "description": "Normative mapping from ACS hooks and decisions to OpenTelemetry spans and span events. v0.1.0 conformance requires that a deployment emitting OTel for the Trace pillar uses these span names and required attributes verbatim. Decisions are recorded as span events on the parent step span, not as separate spans, so that the enforcement verdict and the action it gates share a parent and an OTel context.",
   "type": "object",


### PR DESCRIPTION
## Summary

The v0.1.0 schema package shipped two namespaces, and neither was correct.

| Location | `$id` base at `main` |
|---|---|
| 43 modular subschemas under `specification/v0.1.0/` | `https://acs.org/schema/v0.1.0/` |
| Aggregator `specification/ACS/acs_schema.json` | `https://agentcontrolstandard.org/schema/v0.1.0/` |

Both arrived together in f46d260. This unifies them onto the GitHub Pages namespace for this repository:

```
https://genai-security-project.github.io/agent-control-standard/schema/v0.1.0/
```

## Why

**`acs.org` belongs to the American Chemical Society.** The domain was registered in 1991 and has no relationship to this project. Naming an unrelated organization as the canonical namespace of a security standard is the identity ambiguity ACS exists to make visible. A validator that follows `$id` and retrieves remotely would issue requests to a third party's web server for our canonical schema.

**The namespace split broke reference resolution.** A relative `$ref` resolves against the base URI established by the enclosing `$id`. The aggregator's 36 references therefore resolved to `agentcontrolstandard.org` targets that no `$id` in the package declared. Validators that load by file path never saw this, which is why the package appeared healthy.

## Verification

Resolving every relative `$ref` against its file's `$id` base:

| | before | after |
|---|---|---|
| `$id` values | 44 | 44 |
| duplicate `$id` | 0 | 0 |
| relative `$ref` checked | 73 | 73 |
| **unresolved** | **36** | **0** |
| absolute `http` `$ref` | 0 | 0 |

All 44 files parse as JSON. The path grammar is unchanged, so this is a host swap. The diff touches only URI lines and preserves the two-space document formatting.

## Scope

44 files, 45 insertions, 45 deletions. The extra line is the aggregator, which needed both its `$id` and the prose in its `description` corrected.

No documentation, tooling, or workflow references these hosts, so nothing else changes. `.github/workflows/sync_version.py` deliberately leaves `$id` alone and is unaffected.

## Follow-on work, not in this PR

Remote retrieval still returns 404. GitHub Pages is not enabled on this repository and the schema files are not published under `/schema/v0.1.0/`. This PR fixes the identity, which is what implementers copy and what cannot be corrected later without breaking them. Serving the documents at that identity should land before v0.1.0 has adopters.

Separately, `CLAUDE.md` states that `agentcontrolstandard.ai` is primary with `.org` and `.com` redirecting to it. That no longer matches how the domains are treated and is worth reconciling.
