### PR TITLE
Add current OWASP Nest project metadata

### DIFF
--- a/.github/workflows/validate-owasp-metadata.yaml
+++ b/.github/workflows/validate-owasp-metadata.yaml
@@ -1,0 +1,27 @@
+name: Validate OWASP entity metadata
+
+on:
+  pull_request:
+    paths:
+      - '*.owasp.yaml'
+  push:
+    paths:
+      - '*.owasp.yaml'
+
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}
+
+permissions:
+  contents: read
+
+jobs:
+  validate-metadata:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Validate metadata file
+        uses: owasp/nest-schema/.github/actions/validate@a733198b4a942eb12d3ee8629cd9e0d409b1b2b9

--- a/project.owasp.yaml
+++ b/project.owasp.yaml
@@ -1,0 +1,39 @@
+audience:
+  - builder
+  - defender
+community:
+  - name: agent-control-standard
+    platform: github-discussions
+    url: https://github.com/GenAI-Security-Project/agent-control-standard/discussions
+    description: Specification discussion, questions, and proposals for the Agent Control Standard.
+leaders:
+  - name: Michael Bargury
+    github: mbrg
+  - name: Ory Segal
+    github: oorryy
+level: 2
+license:
+  - Apache-2.0
+  - CC-BY-SA-4.0
+name: OWASP Agent Control Standard
+pitch: >-
+  The open standard for runtime agent control. ACS makes AI agents inspectable,
+  traceable, and instrumentable through declarative hooks, policy enforcement,
+  and a dynamic Agent Bill of Materials, so enterprises can observe and steer
+  the agents they deploy instead of trusting a black box.
+repositories:
+  - name: agent-control-standard
+    url: https://github.com/GenAI-Security-Project/agent-control-standard
+    description: Specification, JSON Schema, and documentation for the Agent Control Standard.
+    code_of_conduct: https://github.com/GenAI-Security-Project/agent-control-standard/blob/main/CODE_OF_CONDUCT.md
+    contribution_guide: https://github.com/GenAI-Security-Project/agent-control-standard/blob/main/CONTRIBUTING.md
+tags:
+  - ai-agents
+  - ai-security
+  - observability
+  - policy-enforcement
+  - runtime-control
+  - agbom
+  - opentelemetry
+type: documentation
+website: https://agentcontrolstandard.org


### PR DESCRIPTION
## Why

OWASP Nest indexes projects from a `project.owasp.yaml` in the project repo. **This repo has never had one on `main`**, so the OWASP index holds no current metadata for ACS and the retired Agent Observability Standard page stands as the canonical public listing.

An `owasp-nest[bot]` push on 2025-10-02 created `nest/owasp-agent-observability-standard-metadata` with a generated draft. No PR was ever opened from it, so it went unreviewed, and the AOS → ACS rebrand landed six months later without it. That branch is now 1 ahead / 23 behind.

## Why the draft wasn't salvageable

```yaml
pitch: A very brief, one-line description of your project
tags: [custom-tag, custom-tag-1, custom-tag-2]
```

Untouched generator placeholders. It also used the retired project name, pointed `website` at the retired `owasp.org` page, listed both superseded OWASP repos including `www-project-agent-observability-standard-2`, and carried a leader email address.

This file is written fresh against the current project.

## What changed versus the draft

| Field | Draft | Now |
|---|---|---|
| `name` | OWASP Agent Observability Standard | OWASP Agent Control Standard |
| `website` | retired `owasp.org` page | `agentcontrolstandard.org` |
| `repositories` | 2 superseded OWASP repos | current repo, with CoC + contributing links |
| `leaders` | included an email | GitHub handles only |
| `license` | `Apache-2.0` | `Apache-2.0` + `CC-BY-SA-4.0` |
| `community` | stale Slack, `aos.owasp.org` | GitHub Discussions |
| `pitch` / `tags` | placeholders | real values |
| `audience` | builder | builder + defender |

`person` requires only `name` in the schema, so leaders carry no email — consistent with #41.

## Verification

- **Validates** against `owasp/nest-schema` `project.json` + `common.json`
- All 5 URLs return 200
- 0 emails, 0 AOS references
- `actions/checkout` pinned to the same SHA as the other workflows, explicit read-only `permissions`, per 81b02b1

## Two things to confirm

1. **Leadership is carried over from the draft unchanged.** Naming OWASP project leaders is a governance decision, not a repo one, so this PR does not alter it. Worth confirming against current leadership.
2. `level: 2` is also carried over unchanged.

The stale bot branch is deleted separately.