### PR TITLE
Record current leadership and reconcile the governance files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,20 +1,24 @@
 # Code owners for the Agent Control Standard.
 #
 # Owners listed here are required reviewers on the paths they own, enforced by
-# the ruleset on main. Everyone below has write access, which GitHub requires
-# for CODEOWNERS entries to take effect.
+# the ruleset on main. GitHub requires write access for an entry to take
+# effect, and fails the entry silently when the handle lacks it.
 #
-# Keep this file in sync with repository collaborator roles. A handle that
-# loses write access stops being a valid owner and GitHub fails the entry
-# silently.
+# Keep this file in sync with repository collaborator roles and with the
+# leadership roster in GOVERNANCE.md.
+#
+# Invited to write access and pending acceptance: @evabenn @RbBuiltWrong
+# @aruneeshsalhotra. An invitation grants nothing until the invitee accepts,
+# so these three entries are inert until then. The other owners on their lines
+# still apply, so review coverage holds meanwhile.
 
 # Default owners for anything not matched below.
-*                       @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @stefanoamorelli @almogbhl @bar-capsule
+*                       @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @stefanoamorelli @almogbhl @bar-capsule @evabenn @RbBuiltWrong @aruneeshsalhotra
 
 # The specification is the highest-blast-radius surface in the repository.
 # A schema change propagates to every downstream implementer.
-/specification/         @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @stefanoamorelli @almogbhl @bar-capsule
-/docs/spec/             @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @stefanoamorelli @almogbhl @bar-capsule
+/specification/         @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @stefanoamorelli @almogbhl @bar-capsule @evabenn @RbBuiltWrong @aruneeshsalhotra
+/docs/spec/             @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @stefanoamorelli @almogbhl @bar-capsule @evabenn @RbBuiltWrong @aruneeshsalhotra
 
 # CI runs with write access to the repository. Changes here are a
 # privilege-escalation surface and warrant admin review.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,43 @@
+# Governance
+
+ACS is an OWASP project. This file records who leads the work, which workstream owns which surface, and how leadership changes.
+
+## Project lead
+
+| Role | Name |
+| --- | --- |
+| Project Lead | Rock Lambros ([@rocklambros](https://github.com/rocklambros)) |
+
+## Workstream leads
+
+Each workstream owns a slice of the standard and runs its own review. Two leads per workstream keeps decisions moving when one is unavailable.
+
+| Workstream | Leads |
+| --- | --- |
+| Coding Agents | Almog Langleben ([@almogbhl](https://github.com/almogbhl)), Stefano Amorelli ([@stefanoamorelli](https://github.com/stefanoamorelli)) |
+| Development (SDK) | Rock Lambros ([@rocklambros](https://github.com/rocklambros)), Fred Wilmot ([@fewdisc](https://github.com/fewdisc)) |
+| Identity | Eva Benn ([@evabenn](https://github.com/evabenn)), Richard Bird |
+| Outreach | Eva Benn ([@evabenn](https://github.com/evabenn)), Aruneesh Salhotra ([@aruneeshsalhotra](https://github.com/aruneeshsalhotra)) |
+| Spec | Bar Kaduri ([@bar-capsule](https://github.com/bar-capsule)), Ariel Fogel ([@afogel](https://github.com/afogel)) |
+
+## Origins
+
+Michael Bargury ([@mbrg](https://github.com/mbrg)) and Ory Segal ([@oorryy](https://github.com/oorryy)) created ACS. Both remain project leaders.
+
+## Why this roster and project.owasp.yaml differ
+
+`project.owasp.yaml` feeds the OWASP Nest project index. Its schema caps `leaders` at five entries and gives each person a name, an email, a GitHub handle, and a Slack handle. No field carries a role, a workstream, or a founding credit.
+
+That file therefore names three people: the project lead and the two creators. This file is the authoritative roster.
+
+## How leadership changes
+
+Existing leads propose additions and removals. The project lead confirms the change, then opens a pull request that touches this file, `project.owasp.yaml`, and `.github/CODEOWNERS` together.
+
+The CODEOWNERS update is not optional. A lead who loses write access stops being a valid owner, and GitHub fails the entry silently rather than flagging it.
+
+## Related
+
+- [CONTRIBUTING.md](./CONTRIBUTING.md) covers how to get involved.
+- [CONTRIBUTORS.md](./CONTRIBUTORS.md) credits contribution, not role.
+- [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) applies to everyone here, leads included.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -16,7 +16,7 @@ Each workstream owns a slice of the standard and runs its own review. Two leads 
 | --- | --- |
 | Coding Agents | Almog Langleben ([@almogbhl](https://github.com/almogbhl)), Stefano Amorelli ([@stefanoamorelli](https://github.com/stefanoamorelli)) |
 | Development (SDK) | Rock Lambros ([@rocklambros](https://github.com/rocklambros)), Fred Wilmot ([@fewdisc](https://github.com/fewdisc)) |
-| Identity | Eva Benn ([@evabenn](https://github.com/evabenn)), Richard Bird |
+| Identity | Eva Benn ([@evabenn](https://github.com/evabenn)), Richard Bird ([@RbBuiltWrong](https://github.com/RbBuiltWrong)) |
 | Outreach | Eva Benn ([@evabenn](https://github.com/evabenn)), Aruneesh Salhotra ([@aruneeshsalhotra](https://github.com/aruneeshsalhotra)) |
 | Spec | Bar Kaduri ([@bar-capsule](https://github.com/bar-capsule)), Ariel Fogel ([@afogel](https://github.com/afogel)) |
 

--- a/project.owasp.yaml
+++ b/project.owasp.yaml
@@ -6,7 +6,13 @@ community:
     platform: github-discussions
     url: https://github.com/GenAI-Security-Project/agent-control-standard/discussions
     description: Specification discussion, questions, and proposals for the Agent Control Standard.
+# The nest-schema caps `leaders` at 5 entries and gives Person no `role` field,
+# so this list carries the project lead and the two creators only. The full
+# leadership roster, workstream assignments, and founding credit live in
+# GOVERNANCE.md. Update both when leadership changes.
 leaders:
+  - name: Rock Lambros
+    github: rocklambros
   - name: Michael Bargury
     github: mbrg
   - name: Ory Segal


### PR DESCRIPTION
## What changed

Records the current ACS leadership and brings the three governance files into agreement.

**`project.owasp.yaml`** — `leaders` becomes Rock Lambros, Michael Bargury, Ory Segal. 83f5632 carried the leader list over from the owasp-nest[bot] draft unchanged and flagged it for confirmation. This confirms it.

**`GOVERNANCE.md`** (new) — the authoritative roster: project lead, five workstreams with two leads each, and the founding credit to Michael Bargury and Ory Segal.

**`.github/CODEOWNERS`** — adds Eva Benn, Richard Bird, and Aruneesh Salhotra to the three broad sections.

## Why the roster is split across two files

The full structure does not fit `project.owasp.yaml`. The OWASP nest-schema:

- sets `additionalProperties: false` with no field for a founding credit
- caps `leaders` at `maxItems: 5`, and the roster names nine people
- gives `Person` only `name`, `email`, `github`, `slack`, so no role or workstream attaches to a person

So the YAML names three and `GOVERNANCE.md` carries the rest. Both files say why they differ, so the next reader does not treat the shorter list as stale and reconcile in the wrong direction.

Michael and Ory stay in `leaders` rather than moving to a credit-only mention. There is no field the schema would accept for that, and both remain project leaders.

## Write access

Eva Benn, Richard Bird, and Aruneesh Salhotra were **invited** to write access alongside this change. An invitation grants nothing until accepted, so their CODEOWNERS entries are inert until each accepts. The other owners on those lines still apply, so review coverage does not drop meanwhile.

The header previously asserted "Everyone below has write access." That became false when these three were added, so it now states the requirement and the silent-failure mode instead.

CI configuration, licensing, and `SECURITY.md` stay with the admin subset. Those are privilege-escalation and foundation-level surfaces.

## Verification

- `project.owasp.yaml` validates against `owasp/nest-schema` `project.json` and `common.json` under Draft 7
- all twelve CODEOWNERS handles resolve to live profiles
- every GitHub profile URL in `GOVERNANCE.md` returns 200
- Richard Bird confirmed as `@RbBuiltWrong` and backfilled into `GOVERNANCE.md`
- Slack profile artifacts stripped from two names: `(Mobile)` on Eva Benn, and a bracketed project list on Aruneesh Salhotra

## Not in this PR

CODEOWNERS lists `@GangGreenTemperTatum`, `@mamicidal`, and `@sclintonowasp`, none of whom appear in the leadership roster. Not necessarily wrong, but the two lists have diverged and that is worth a separate look.
