### PR TITLE
Record that the site is live and how to roll it back

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,8 +94,8 @@ This is a documentation-focused project built with:
 
 ### Hosting (decoupled from this repo)
 This repository is the source of truth for the ACS spec, and it now carries the workflow
-that publishes the site. Once Pages is enabled, `.github/workflows/deploy-pages.yml`
-builds three things on every merge to `main`: the landing page from `landing/`, the
+that publishes the site. `.github/workflows/deploy-pages.yml` builds three things on
+every merge to `main`: the landing page from `landing/`, the
 MkDocs documentation under `/docs/`, and the JSON schemas under `/schema/<spec-version>/`.
 
 Schema publish paths derive from each schema's own `$id`, which is validated and
@@ -134,10 +134,10 @@ Schema `$id` values are based at `https://genai-security-project.github.io/agent
 
 `$id` is identity, not a fetch target. Every `$ref` in the package is relative and resolves against the enclosing `$id` base, so the whole set must share one base. Two bases means the relative refs resolve to URIs no `$id` declares, which is the defect fixed in `4fb84c1`. If you add a subschema, give it an `$id` under the same base and keep its refs relative.
 
-The base is served once GitHub Pages is enabled on this repository, which
-`.github/workflows/deploy-pages.yml` then publishes to on every merge to `main` and
-`.github/workflows/monitor-pages.yml` rechecks every six hours. Until that setting is
-turned on, remote retrieval 404s and only local and file-path validation works.
+The base is served. `.github/workflows/deploy-pages.yml` publishes every schema at the
+path its `$id` declares on each merge to `main`, and the deploy fails if any of them
+does not resolve. `.github/workflows/monitor-pages.yml` rechecks every six hours. All 44
+URIs were confirmed resolving on the first deploy.
 
 `$id` is versioned by **spec** version, not release version. `.github/workflows/sync_version.py` deliberately leaves `$id` alone. See `1af1f92`.
 

--- a/design/2026-09-05-github-pages-landing.md
+++ b/design/2026-09-05-github-pages-landing.md
@@ -239,3 +239,24 @@ Do not rebase `$id` onto the marketing domain during the cutover.
   repository and resolve when the redirect lands.
 - Seven A2A hook pages under `docs/spec/instrument/a2a/hooks/` are absent from the MkDocs
   navigation. They publish as orphans reachable only by direct URL. Tracked separately.
+
+## Rollback
+
+A build failure needs no rollback. Pages keeps serving the last successful deployment.
+
+A successful deploy of wrong content does. In order of speed:
+
+1. Re-run the deploy job of the last good workflow run from the Actions tab. Artifact
+   retention is 30 days, so this stays available for a month.
+2. `git revert` the offending commit, then merge. This takes a full pipeline run.
+
+Both are available to anyone with write access. The scheduled monitor in
+`.github/workflows/monitor-pages.yml` checks every six hours that the schema endpoints
+still serve their own `$id`, so a silent regression surfaces within that window rather
+than waiting for a consumer to report it.
+
+## Status
+
+The site went live on 2026-09-05. The first deploy succeeded, and all 44 schema URIs were
+confirmed serving their own `$id`. The `github-pages` environment is restricted to
+protected branches, which is the second layer behind the workflow's own branch check.


### PR DESCRIPTION
Follow-up to #45, deliberately deferred until the URIs were confirmed resolving.

The hosting notes in `CLAUDE.md` were written conditionally while Pages was disabled, so they described what would happen rather than what does. Writing them earlier would have traded one false statement for another.

Also records the rollback procedure the design carried as an open item, and the live status: first deploy succeeded, all 44 schema URIs confirmed serving their own `$id`, environment restricted to protected branches.