### PR TITLE
docs: replace 'verifiable audit trail' overclaim with honest vocabulary

### DIFF
--- a/docs/acs.md
+++ b/docs/acs.md
@@ -1,6 +1,6 @@
 # Agent Control Standard
 
-The Agent Control Standard (ACS) is a wire-format specification that lets a separate **Guardian Agent** permit, deny, or modify what an AI agent does in real time, over an authenticated channel and with a verifiable audit trail.
+The Agent Control Standard (ACS) is a wire-format specification that lets a separate **Guardian Agent** permit, deny, or modify what an AI agent does in real time, over an authenticated channel and with an observable, reconstructable audit trail.
 
 Agents that implement ACS-Core run every step through a Guardian over an authenticated channel and honor its decisions in real time. With the Trace, Inspect, and Crypto profiles they also emit OpenTelemetry spans and OCSF events, expose a dynamic Agent Bill of Materials (models, MCP servers, A2A peers, tools, knowledge sources, memory stores), and gain cryptographic non-repudiation of the audit chain. ACS-Core authenticates the channel and binds the agent to the Guardian's decisions; it does not by itself make a deployment secure or its policies strict, and tamper-evidence against a compromised Guardian is the Crypto and Audit profiles, not Core.
 

--- a/docs/spec/trace/README.md
+++ b/docs/spec/trace/README.md
@@ -23,7 +23,7 @@ Modern agents orchestrate complex workflows: reasoning chains, tool execution, k
 
 **Performance**: Identify bottlenecks in reasoning chains. Optimize tool usage patterns. Monitor resource consumption across agent workflows.
 
-**Trust**: Verifiable audit trails for regulatory compliance. Explainable decisions for stakeholder confidence.
+**Trust**: Observable, reconstructable audit trails for regulatory compliance. Trace events are self-reported observations produced inside the environment being observed; they become evidence only when a party outside the emitting runtime attests to them (see the verifier-side discussion in issue #18). Explainable decisions for stakeholder confidence.
 
 ## How It Works
 

--- a/docs/topics/core_concepts.md
+++ b/docs/topics/core_concepts.md
@@ -1,6 +1,6 @@
 # Core Concepts
 
-ACS specifies how an AI agent exposes its behavior so a separate **Guardian Agent** can permit, deny, or modify what the agent does, in real time, with a verifiable audit trail. The agent being monitored is an **Observed Agent**.
+ACS specifies how an AI agent exposes its behavior so a separate **Guardian Agent** can permit, deny, or modify what the agent does, in real time, with an observable, reconstructable audit trail. The agent being monitored is an **Observed Agent**.
 
 ## The three pillars
 


### PR DESCRIPTION
## Summary

Implements the correction suggested in #36: ACS documentation currently claims **"verifiable audit trail(s)"** in three places. That overstates what the spec's Core and Trace profile deliver today.

Trace events are **self-reported observations produced inside the runtime being observed**. They become verifiable evidence only when a party *outside* the emitting runtime attests to them — which is a verifier-side primitive, tracked in #18. Until that primitive exists, the docs should describe what ACS actually provides.

## Changes

Replace "verifiable audit trail(s)" with **"observable, reconstructable audit trail(s)"** in:

- `docs/acs.md` — specification overview
- `docs/topics/core_concepts.md` — core concepts
- `docs/spec/trace/README.md` — Trace profile ("Trust" goal)

No behavioural or wire-format changes. Pure documentation honesty fix.

## Notes

- Scope kept surgical: vocabulary correction only, no new channel/feature language introduced.
- Relates to #18 (verifier-side primitive) — the language here can be strengthened back once that lands.

Closes #36
