### PR TITLE
Give the approver model its own section heading

### DIFF
--- a/docs/spec/instrument/specification.md
+++ b/docs/spec/instrument/specification.md
@@ -254,6 +254,8 @@ For every step where the Guardian writes a ContextEntry (the content-bearing ste
 
 Tamper-evidence here is bounded by the signature in use. Under the HMAC baseline the published, signed head gives integrity against a network tamperer and lets a key-holder verify the chain, but it does not bind the Guardian itself: the Guardian holds the symmetric key and can re-sign a rewritten head. Non-repudiation, proving to a third party that a specific Guardian issued a specific head, requires the asymmetric ACS-Crypto profile. The baseline detects accidental divergence and cross-Guardian disagreement; defeating a determined, compromised Guardian is a profile-level guarantee, not a Core one.
 
+## 9. Approver Model
+
 ASK approvers MAY be human, agent, or service. `ask_details.approver = { type, id, endpoint }`. The Approver receives an ACS-shaped request and returns an ACS-shaped decision. Approver authentication is REQUIRED. Guardian MUST verify approver identity against policy.
 
 Single-hop only in v0.1. Approvers MUST NOT return ASK. Quorum and recursive ASK deferred to v0.2.

--- a/tests/test_spec_structure.py
+++ b/tests/test_spec_structure.py
@@ -1,0 +1,54 @@
+"""Heading structure guards for the specification documents.
+
+A subsection renders under whichever heading precedes it. When a numbered
+subsection has no parent heading, its prose silently joins the previous
+section, the section gets no anchor, and it never appears in the page table of
+contents. Nothing fails the build, so only a structural check catches it.
+"""
+
+import re
+from pathlib import Path
+
+DOCS = Path(__file__).resolve().parent.parent / "docs"
+
+# `### 9.1 Intent extension via ASK (normative)` -> ("9", "1")
+SUBSECTION = re.compile(r"^#{3,6}\s+(\d+)\.(\d+)\b")
+# `## 9. Approver Model` -> "9"
+SECTION = re.compile(r"^##\s+(\d+)\.")
+
+
+def numbered_spec_documents():
+    """Every docs page that numbers its sections, so the rule stays scoped."""
+    for path in sorted(DOCS.rglob("*.md")):
+        lines = path.read_text(encoding="utf-8").splitlines()
+        if any(SECTION.match(line) for line in lines):
+            yield path
+
+
+def test_every_numbered_subsection_has_a_parent_section():
+    orphans = []
+    for path in numbered_spec_documents():
+        lines = path.read_text(encoding="utf-8").splitlines()
+        parents = {SECTION.match(line).group(1) for line in lines if SECTION.match(line)}
+        for number, line in enumerate(lines, start=1):
+            match = SUBSECTION.match(line)
+            if match and match.group(1) not in parents:
+                orphans.append(
+                    f"{path.relative_to(DOCS.parent)}:{number} "
+                    f"'{line.strip()}' has no '## {match.group(1)}.' parent"
+                )
+    assert not orphans, "Numbered subsections with no parent section:\n" + "\n".join(orphans)
+
+
+def test_numbered_sections_run_without_gaps():
+    """A missing parent heading also shows up as a gap in the section sequence."""
+    gaps = []
+    for path in numbered_spec_documents():
+        lines = path.read_text(encoding="utf-8").splitlines()
+        found = [int(SECTION.match(line).group(1)) for line in lines if SECTION.match(line)]
+        if not found:
+            continue
+        missing = sorted(set(range(min(found), max(found) + 1)) - set(found))
+        if missing:
+            gaps.append(f"{path.relative_to(DOCS.parent)} skips section(s) {missing}")
+    assert not gaps, "Numbered section sequences with gaps:\n" + "\n".join(gaps)


### PR DESCRIPTION
## What

`docs/spec/instrument/specification.md` numbers every section `## N.` except section 9, which had none. The approver model at what should be §9 opened directly with body prose, so it rendered as the tail of `### 8.6 Chain head publication (normative)`.

Adds `## 9. Approver Model` ahead of that prose, matching the shape §4 already uses (a `## N.` heading, body text, then `### N.1`).

## Why it went unnoticed

A subsection renders under whichever heading precedes it, so an orphaned `### 9.1` builds clean under `--strict`. Nothing failed. The effects were all silent:

- Approver rules read as part of chain-head publication
- Section 9 had no anchor and no table-of-contents entry
- `concepts/intent.md`, `concepts/identity.md`, and `concepts/agents.md` each send readers to §9, which the page did not appear to contain

This is not a regression. No blob anywhere in the repository's history contains a line starting `## 9`, so it dates to the canonical v0.1.0 import in `f46d260`.

## Guard

`tests/test_spec_structure.py` asserts two things across every numbered document, not just this one:

- every numbered subsection has a matching `## N.` parent
- the numbered section sequence runs without gaps

Both failed before the fix, naming section 9 specifically and nothing else. Both pass after.

## Verification

- `uv run pytest` 194 passed, 1 skipped (up from 192, the two new guards)
- `uv run mkdocs build --strict` exits 0
- Built page carries `id="9-approver-model"`, and `#92-approver-incapable-clients-normative` is unchanged, so the existing §9.2 link at line 113 still resolves

## Not changed

The three concept pages refer to `(§9)` as bare text. That matches the local convention for those "Referenced by" footers, which link the file and leave section numbers bare, so I left them alone.

## Type of change

- [ ] Specification change (schema, hooks, events, AgBOM)
- [x] Documentation
- [ ] Tooling or CI
- [ ] Governance

## Security

- [x] This change has no security impact