### PR TITLE
Add a docs navigation link back to the ACS landing page

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,11 @@ extra:
       link: https://github.com/GenAI-Security-Project/agent-control-standard/discussions
 
 nav:
+  # The landing page links into the docs, so the docs need the return path. The URL is
+  # absolute rather than derived from site_url because site_url names the /docs/ subpath,
+  # which cannot address its own parent. It survives the agentcontrolstandard.org
+  # cutover, when the custom domain makes this URL redirect rather than break.
+  - ACS home: https://genai-security-project.github.io/agent-control-standard/
   - Trustworthy Agents: README.md
   - ACS: acs.md
   - Topics:


### PR DESCRIPTION
The landing page links into the documentation, but the documentation had no way back. This adds a top-level nav entry pointing at the site root.

The URL is absolute rather than derived from `site_url`, because `site_url` names the `/docs/` subpath and cannot address its own parent. It stays correct through the agentcontrolstandard.org cutover, when the custom domain makes this URL redirect rather than break.

Verified with `mkdocs build --strict` (exit 0) and the rendered link confirmed on both the index and nested pages.