### PR TITLE
Close three pre-relaunch gates: pytest scope, licensing catch-all, conformance attestation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,12 @@ This project follows our [Code of Conduct](./CODE_OF_CONDUCT.md). By participati
 uv pip install -e .          # install dependencies
 uv run mkdocs serve          # preview docs at http://localhost:8000
 uv run mkdocs build          # build static docs
+uv run pytest -v             # run the guards (same command CI runs)
 ```
+
+The guards in `tests/` check things the build itself will not catch, including spec heading structure, published schema URIs, and the third-party asset rules for the site. They run in the `test` job of `deploy-pages.yml`, and the build job depends on them, so a failing guard blocks the deploy rather than shipping a broken page.
+
+Put new guards in `tests/`. Collection is scoped there by `testpaths` in `pyproject.toml`, so a test written anywhere else never runs in CI and will pass review looking like coverage it does not provide. A suite that needs dependencies outside `uv.lock` belongs in its own workflow with its own environment, because the deploy gate installs only what the lockfile carries.
 
 For prose contributions, follow the [editorial style guide](./STYLE.md). For schema contributions, validate `specification/v0.1.0/acs_schema.json` against the JSON Schema spec before submitting.
 

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -18,6 +18,9 @@ Copyright 2025-2026 The OWASP GenAI Security Project and the ACS contributors.
 | `overrides/**` | CC BY-SA 4.0 | `CC-BY-SA-4.0` |
 | `design/**` | CC BY-SA 4.0 | `CC-BY-SA-4.0` |
 | `landing/assets/fonts/**` | SIL Open Font License 1.1 | `OFL-1.1` |
+| Everything else, including any new top-level directory | Apache License 2.0 | `Apache-2.0` |
+
+A more specific row wins over the catch-all. The catch-all exists so a directory added later is governed the day it lands rather than on the day someone notices it was never listed. Apache 2.0 is the default because a new directory is usually code, and an over-permissive grant on prose costs less than a ShareAlike obligation attaching by accident to reference code that adopters copy into their own systems. When a new directory holds prose, add an explicit `CC-BY-SA-4.0` row for it in the same pull request that creates it.
 
 Full texts live in [`LICENSE`](./LICENSE) for Apache 2.0, [`LICENSE-DOCS`](./LICENSE-DOCS) for CC BY-SA 4.0, and [`landing/assets/fonts/OFL.txt`](./landing/assets/fonts/OFL.txt) for the SIL Open Font License 1.1. Attribution details live in [`NOTICE`](./NOTICE).
 

--- a/docs/spec/conformance.md
+++ b/docs/spec/conformance.md
@@ -29,6 +29,8 @@ ACS-Core does NOT require: field-level Provenance objects, Trace event emission,
 
 What "ACS-Core conformant" guarantees: the channel is authenticated and the Observed Agent honors the Guardian's decisions. It does NOT assert that a deployment's policies are strict, nor that the audit chain is tamper-evident against a compromised Guardian (that is the ACS-Crypto and ACS-Audit profiles, since the HMAC baseline is symmetric). A permissive Guardian is a conformant but permissive deployment, not a violation.
 
+Who verifies a conformance claim: nobody, in v0.1.0. `profiles_supported` and `profiles_accepted` are self-declaration on the wire. This release ships no conformance test suite, no registry of conformant implementations, and no steward body to arbitrate a disputed claim. A deployment that advertises "ACS-Core conformant" is asserting that about itself, and a buyer who procures on that basis is trusting the implementer rather than a third party. Test the deployment against the requirements above the way you would check any other vendor claim. A conformance suite and the governance to operate it are tracked in [issue #19](https://github.com/GenAI-Security-Project/agent-control-standard/issues/19) and scoped to a later release.
+
 ## ACS-Trace
 
 Adds deterministic Trace event emission per [Trace Events](./trace/events.md). A deployment claiming ACS-Trace MUST:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,12 @@ dependencies = [ "mike>=1.2.0", "mkdocs-material>=9.6.14", "pymdown-extensions>=
 
 [dependency-groups]
 dev = [ "pytest>=8.0", "jsonschema>=4.25.0",]
+
+[tool.pytest.ini_options]
+# The deploy workflow runs a bare `uv run pytest -v` as the gate the site build
+# depends on, in the environment `uv sync --locked` produces. Without this,
+# pytest collects the whole repository, so any suite whose dependencies are not
+# in uv.lock fails at collection and takes the deploy down with it. Scoping
+# collection to tests/ keeps that gate about the guards it was written for.
+# Suites that carry their own dependencies run from their own workflow.
+testpaths = ["tests"]


### PR DESCRIPTION
Three pre-relaunch gates, each independently revertable.

**Scope pytest collection to `tests/`.** The site build depends on a bare `uv run pytest -v` running in the environment `uv.lock` produces. With no `testpaths`, pytest collects the whole repository, so a suite whose dependencies sit outside the lockfile fails at collection and takes the deploy with it. PR #22 adds 23 adapter test files needing `rfc8785`, `nvidia-nat-core`, and `ruamel`, none of them locked. Measured against a real merged tree:

| `pyproject.toml` | Collection |
| --- | --- |
| before | 206 collected, 22 errors, interrupted |
| after | 195 collected, 0 errors |

Interrupted collection exits nonzero, which fails the `test` job, which stops the `build` job that declares `needs: test`. On `main` as it stands today the change is inert: 194 passed and 1 skipped both with and without it, because nothing currently lives outside `tests/`.

CONTRIBUTING now says where guards belong and why a test written elsewhere never runs. That silence is what let two contributors build suites CI would not have executed.

**Give `LICENSING.md` a catch-all row.** The table mapped ten paths and stopped, so a new top-level directory arrived governed by nothing until someone noticed. `adapters/` is the next one due. Apache 2.0 is the default because a new directory is usually code, and an over-permissive grant on prose costs less than a ShareAlike obligation attaching by accident to reference code that adopters copy into their own systems. A prose directory still wants its own explicit `CC-BY-SA-4.0` row.

**Say who verifies an ACS-Core conformance claim.** Nobody does, in v0.1.0. `profiles_supported` and `profiles_accepted` are self-declaration on the wire, and this release ships no conformance suite, no registry, and no steward to arbitrate a disputed claim. The page described what the label guarantees without saying the label is the implementer's own assertion, which is the gap issue #19 raised. The paragraph sits below the ACS-Core requirement list rather than inside it, so the `conformance.md` line numbers PR #22's citation guard pins do not move.

Closes part of #19.
