### PR TITLE
Add the skill lifecycle hooks to the taxonomy table

### DIFF
--- a/docs/spec/instrument/specification.md
+++ b/docs/spec/instrument/specification.md
@@ -96,8 +96,11 @@ Hook details, payloads, and per-hook examples are catalogued on the [Hooks](./ho
 | 12 | `postCompact` | After compaction; carries the new summary's payload and provenance |
 | 13 | `subagentStart` | A subagent is spawned (in-process delegation) |
 | 14 | `subagentStop` | A subagent has terminated |
-| 15 | `turnEnd` | End of an agent turn |
-| 16 | `sessionEnd` | Session termination, audit finalization |
+| 15 | `skillRegister` | Skill enters the available set, before it can load; decision-eligible |
+| 16 | `skillLoad` | Registered skill activates into a session, before its actions run; decision-eligible |
+| 17 | `skillUnload` | Skill leaves the active set |
+| 18 | `turnEnd` | End of an agent turn |
+| 19 | `sessionEnd` | Session termination, audit finalization |
 
 Wrapped: `protocols/MCP/*` (specified in v0.1; see [Extending MCP](./extend_mcp.md)). The `protocols/A2A/*` namespace is reserved; wrapping specification deferred to v0.2.
 

--- a/tests/test_hook_taxonomy.py
+++ b/tests/test_hook_taxonomy.py
@@ -1,0 +1,111 @@
+"""Hook taxonomy guards for the Instrument pillar documents.
+
+The hook set is stated in three places: the schemas under
+`specification/v0.1.0/hooks/`, the overview table on the Hooks page, and the
+taxonomy table in Specification section 5. The schemas are the normative
+source; the two tables are readable views of the same set.
+
+Nothing binds the views to the source. When the skill lifecycle hooks landed,
+they reached the schemas and the Hooks page but not the taxonomy table, so the
+specification page listed sixteen hooks while the Hooks page listed nineteen.
+A reader treating the specification page as canonical never learned that skills
+are governable, and the omission propagated into implementations. The build
+stayed green throughout, so only a check that reads the schemas catches it.
+"""
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+HOOK_SCHEMAS = ROOT / "specification" / "v0.1.0" / "hooks"
+SPECIFICATION = ROOT / "docs" / "spec" / "instrument" / "specification.md"
+HOOKS_PAGE = ROOT / "docs" / "spec" / "instrument" / "hooks.md"
+
+# `steps/skillRegister payload` -> "skillRegister". The profile variants title
+# themselves `... payload (ACS-Provenance profile)` and are the same hook, so
+# anchoring the end of the string collapses them to one entry.
+SCHEMA_TITLE = re.compile(r"^steps/([A-Za-z][A-Za-z0-9]*) payload$")
+# `| 15 | `skillRegister` | Skill enters ...` -> ("15", "skillRegister")
+TAXONOMY_ROW = re.compile(r"^\|\s*(\d+)\s*\|\s*`([A-Za-z][A-Za-z0-9]*)`\s*\|")
+# `| [`skillRegister`](#skillregister) | Skill enters ...` -> "skillRegister".
+# Namespaced entries (`agbom/snapshot`, `system/ping`, `protocols/MCP/*`) carry
+# a slash, so they do not match and stay out of the native set.
+OVERVIEW_ROW = re.compile(r"^\|\s*\[?`([A-Za-z][A-Za-z0-9]*)`")
+# `ACS v0.1.0 defines 19 native `steps/*` hooks` -> "19"
+STATED_COUNT = re.compile(r"defines (\d+) native `steps/\*` hooks")
+
+
+def native_hook_methods():
+    """The normative hook set, read from the schemas' own declared titles."""
+    methods = set()
+    for path in sorted(HOOK_SCHEMAS.glob("*.json")):
+        title = json.loads(path.read_text(encoding="utf-8")).get("title", "")
+        match = SCHEMA_TITLE.match(title)
+        if match:
+            methods.add(match.group(1))
+    return methods
+
+
+def section(path, heading):
+    """Lines under a `## ` heading, stopping at the next one."""
+    lines = path.read_text(encoding="utf-8").splitlines()
+    start = next(i for i, line in enumerate(lines) if line.startswith(heading))
+    for offset, line in enumerate(lines[start + 1 :], start=start + 1):
+        if line.startswith("## "):
+            return lines[start + 1 : offset]
+    return lines[start + 1 :]
+
+
+def test_specification_taxonomy_lists_every_native_hook():
+    rows = [
+        TAXONOMY_ROW.match(line)
+        for line in section(SPECIFICATION, "## 5. Hook Taxonomy")
+    ]
+    listed = {match.group(2) for match in rows if match}
+    expected = native_hook_methods()
+
+    missing = sorted(expected - listed)
+    unknown = sorted(listed - expected)
+    assert not missing, (
+        "Specification section 5 omits hooks the schemas define: "
+        + ", ".join(missing)
+    )
+    assert not unknown, (
+        "Specification section 5 lists hooks with no schema: " + ", ".join(unknown)
+    )
+
+
+def test_specification_taxonomy_numbering_runs_without_gaps():
+    numbers = [
+        int(match.group(1))
+        for line in section(SPECIFICATION, "## 5. Hook Taxonomy")
+        if (match := TAXONOMY_ROW.match(line))
+    ]
+    assert numbers == list(range(1, len(numbers) + 1)), (
+        f"Specification section 5 numbering is not 1..{len(numbers)}: {numbers}"
+    )
+
+
+def test_hooks_page_overview_lists_every_native_hook():
+    rows = [OVERVIEW_ROW.match(line) for line in section(HOOKS_PAGE, "## Overview")]
+    listed = {match.group(1) for match in rows if match}
+    expected = native_hook_methods()
+
+    missing = sorted(expected - listed)
+    unknown = sorted(listed - expected)
+    assert not missing, (
+        "Hooks page overview omits hooks the schemas define: " + ", ".join(missing)
+    )
+    assert not unknown, (
+        "Hooks page overview lists hooks with no schema: " + ", ".join(unknown)
+    )
+
+
+def test_hooks_page_states_the_real_hook_count():
+    match = STATED_COUNT.search(HOOKS_PAGE.read_text(encoding="utf-8"))
+    assert match, "Hooks page no longer states a native `steps/*` hook count"
+    expected = len(native_hook_methods())
+    assert int(match.group(1)) == expected, (
+        f"Hooks page claims {match.group(1)} native hooks; the schemas define {expected}"
+    )


### PR DESCRIPTION
## What changed

Specification section 5 listed sixteen hooks; the Hooks page lists nineteen. The gap is the entire skill lifecycle set (`skillRegister`, `skillLoad`, `skillUnload`), which reached the schemas, the Hooks page, `conformance.md`, and the `skill` AgBOM component type but never the taxonomy table. This adds the three hooks and renumbers the table to nineteen, then guards the set with a test.

## Type of change

- [ ] Specification change (schema, hooks, events, AgBOM)
- [x] Documentation
- [x] Tooling or CI
- [ ] Governance (licensing, security policy, contributor docs)

## Specification changes

No normative content changes. The three hooks were already normative in `specification/v0.1.0/hooks/` and already documented on the Hooks page. This corrects a summary table that had drifted from them, and it deliberately does not restate the skill rationale, which stays on the Hooks page.

**Breaking for implementers?** No. Nothing on the wire changes. The practical effect is the reverse of breaking: implementers reading the specification page as canonical were never told skills are governable, so all three adapters in #22 emit no skill hooks at all.

## Why it matters

`skillRegister` is the one point where a Guardian inspects a whole skill definition before any of its actions run. A payload split across a skill's actions is benign at each action and malicious only in composition, so per-action hooks cannot catch it. Omitting the set from the table people treat as the hook list quietly removed that gate from view.

## The guard

`tests/test_hook_taxonomy.py` reads the `title` field of every schema under `specification/v0.1.0/hooks/` as the normative source, then checks it against the section 5 table, the Hooks page overview table, and the hook count the Hooks page states, plus contiguous numbering.

Verified by injection rather than by inspection. Reverting the table fails with `Specification section 5 omits hooks the schemas define: skillLoad, skillRegister, skillUnload`; changing the stated count fails with `Hooks page claims 16 native hooks; the schemas define 19`.

This drift happened with a green build from start to finish, so only a check that reads the schemas prevents a repeat.

## Not in scope

`docs/acs.md` carries the same defect ("16 native lifecycle hooks", skill hooks absent), but #21 already rewrites that exact line and names the skill hooks. Fixing it here would conflict with that PR for no gain. If #21 does not land, that line still needs the fix.

The skill hooks also have no OpenTelemetry span or OCSF class in `specification/v0.1.0/trace/`, so ACS-Trace cannot cover them today. That is a normative decision rather than a doc correction and is filed separately.

## Checklist

- [x] Commits are signed off with `git commit -s` (required by the DCO)
- [x] Prose follows [STYLE.md](../STYLE.md)
- [x] `uv run mkdocs build --strict` passes
- [x] No secrets, tokens, or internal URLs in the diff

Full suite: 198 passed, 1 skipped.
