### PR TITLE
Say that commits land under human authorship

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,8 @@ All submissions go through GitHub pull request review. See [GitHub's PR guide](h
 
 For changes to the spec itself (`acs_schema.json`, hooks, events), open a [Discussion](https://github.com/GenAI-Security-Project/agent-control-standard/discussions) before submitting a PR. These affect downstream implementers and warrant a longer conversation.
 
+Commits land under human authorship. Many of us write with AI assistance, and the project takes no position on which tools you use. The sign-off is what matters here. The DCO below is a certification a person makes about the origin of the code, and only a person can make it. Keep your `Signed-off-by` line, and leave AI tools out of the commit trailers. If a `Co-Authored-By` naming a model reaches a pull request, a maintainer drops it when the pull request is squashed, and your authorship and sign-off carry through unchanged.
+
 ## What We Need
 
 **High Priority:**


### PR DESCRIPTION
## What changed

Adds a paragraph to `CONTRIBUTING.md` saying that commits land under human authorship, and that AI tools do not belong in commit trailers.

PR #59 arrived with `Co-Authored-By` and `Claude-Session` trailers naming a model. The trailers were dropped in the squash, which is the right outcome reached the wrong way: nothing in `CONTRIBUTING.md`, `STYLE.md`, or `.github/` said the rule, so the contributor could not have known it before merge time. This writes it down.

The reasoning is the DCO, which already sits a few sections below in the same file. A sign-off is a certification a person makes about the origin of the code, and a model cannot make one. Naming a model as co-author puts a party in the trailer that cannot stand behind the certification the next line asserts. The paragraph says the project takes no position on which tools contributors write with, because it does not need to.

Placement is deliberate. It goes in Development Process, right after the spec-Discussion note and next to the sign-off step it depends on. That keeps it clear of the adapters hunk PR #22 adds higher in the same file, so both land without a conflict.

## Type of change

- [ ] Specification change (schema, hooks, events, AgBOM)
- [ ] Documentation
- [ ] Tooling or CI
- [X] Governance (licensing, security policy, contributor docs)

## Checklist

- [X] Commits are signed off with `git commit -s` (required by the DCO)
- [X] Prose follows [STYLE.md](../STYLE.md)
- [X] `uv run mkdocs build --strict` passes
- [X] No secrets, tokens, or internal URLs in the diff

## Security

- [X] This change has no security impact
