### PR TITLE
Give the spec workstream leads owner parity

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,11 +15,11 @@
 # Default owners for anything not matched below.
 *                       @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @stefanoamorelli @almogbhl @bar-capsule @evabenn @RbBuiltWrong @aruneeshsalhotra
 
-/CLAUDE.md       @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp
-/.gitignore     @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp
-/STYLE.md        @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp
-/CONTRIBUTING.md @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp
-/design/         @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp
+/CLAUDE.md       @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @bar-capsule
+/.gitignore     @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @bar-capsule
+/STYLE.md        @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @bar-capsule
+/CONTRIBUTING.md @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @bar-capsule
+/design/         @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @bar-capsule
 
 # The specification is the highest-blast-radius surface in the repository.
 # A schema change propagates to every downstream implementer.
@@ -33,24 +33,25 @@
 # the build renders into every page, which carries the same reach.
 # The docs stylesheet and asset directories render into every documentation page and
 # can reach a third party through url(), @font-face, or @import with no script at all.
-/tools/         @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp
-/landing/       @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp
-/GOVERNANCE.md  @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp
-/mkdocs.yml     @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp
-/pyproject.toml @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp
-/uv.lock        @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp
-/tests/         @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp
-/overrides/     @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp
-/docs/stylesheets/ @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp
-/docs/assets/      @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp
+/tools/         @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @bar-capsule
+/landing/       @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @bar-capsule
+/GOVERNANCE.md  @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @bar-capsule
+/mkdocs.yml     @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @bar-capsule
+/pyproject.toml @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @bar-capsule
+/uv.lock        @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @bar-capsule
+/tests/         @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @bar-capsule
+/overrides/     @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @bar-capsule
+/docs/stylesheets/ @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @bar-capsule
+/docs/assets/      @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @bar-capsule
 
 # CI runs with write access to the repository. Changes here are a
-# privilege-escalation surface and warrant admin review.
-/.github/               @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp
+# privilege-escalation surface, so this list stays narrower than the default
+# and who sits on it is a project-lead decision under GOVERNANCE.md.
+/.github/               @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @bar-capsule
 
 # Licensing and security policy changes are governance decisions.
-/LICENSE                @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp
-/LICENSE-DOCS           @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp
-/LICENSING.md           @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp
-/NOTICE                 @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp
-/SECURITY.md            @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp
+/LICENSE                @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @bar-capsule
+/LICENSE-DOCS           @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @bar-capsule
+/LICENSING.md           @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @bar-capsule
+/NOTICE                 @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @bar-capsule
+/SECURITY.md            @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @bar-capsule


### PR DESCRIPTION
## What changed

Adds `@afogel` and `@bar-capsule` to all 21 restricted CODEOWNERS lines, giving the Spec workstream leads owner parity with the project leads.

PR #59 is the case that prompted this. It fixed a real defect in `response-envelope.json` and shipped `tests/test_response_envelope.py` to prove the fix. `@bar-capsule` approved it and the merge stayed blocked, because CODEOWNERS granted the spec leads `/specification/` and `/docs/spec/` but not `/tests/`, `/pyproject.toml`, or `/uv.lock`. A spec lead could approve the schema change and not the test that holds it to its own contract.

That splits one reviewable change across two owner tiers, and it recurs on every spec PR that carries its own coverage, which should be all of them. A narrower grant covering only `/tests/` and the packaging files would unblock that exact case and leave the same seam waiting somewhere else, so both handles join every restricted line instead of a chosen subset.

Both already hold `maintain` on the repository, so the entries take effect on merge rather than failing silently the way the header warns about.

The `/.github/` comment claimed those paths warrant admin review. Both new owners hold `maintain`, so that comment no longer described the list it sat above. It now says what the narrow list is for and points at `GOVERNANCE.md` for who decides membership.

## Type of change

- [ ] Specification change (schema, hooks, events, AgBOM)
- [ ] Documentation
- [ ] Tooling or CI
- [X] Governance (licensing, security policy, contributor docs)

## Worth a reviewer's attention

`GOVERNANCE.md:35` says a leadership change opens a PR touching `GOVERNANCE.md`, `project.owasp.yaml`, and `.github/CODEOWNERS` together. This PR touches only CODEOWNERS, on the reading that it is not a leadership change: `@afogel` and `@bar-capsule` are already Spec workstream leads at `GOVERNANCE.md:21`, and this widens what they own rather than who they are. `project.owasp.yaml` carries no role field and caps `leaders` at five, so nothing there changes either.

The part that deserves a second opinion is the workstream table. It frames each workstream as owning a slice of the standard, and after this the Spec leads own every path in the repository. If that reads as a role change rather than a scope change, `GOVERNANCE.md` should say so, and I would rather a reviewer make that call than assume it.

## Checklist

- [X] Commits are signed off with `git commit -s` (required by the DCO)
- [X] Prose follows [STYLE.md](../STYLE.md)
- [X] `uv run mkdocs build --strict` passes
- [X] No secrets, tokens, or internal URLs in the diff

## Security

This change has security relevance and is worth stating plainly rather than checking a box.

`/.github/` is a privilege-escalation surface, because CI runs with write access to the repository. This PR grants two more people the ability to approve changes to it, along with `/LICENSE`, `/SECURITY.md`, `/LICENSING.md`, `/NOTICE`, and `/GOVERNANCE.md`. The ruleset still requires an approving review and still blocks self-approval through `require_last_push_approval`, so no single person can land a workflow change alone. The grant is deliberate and made by the project lead under `GOVERNANCE.md:35`.
