### PR TITLE
Install the contribution governance for the OWASP re-launch

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -1,0 +1,53 @@
+name: Bug report
+description: Something is broken in the specification, a schema, the site, CI, or tooling.
+title: "[Bug] "
+labels: ["type:bug", "status:needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        Do not file a security vulnerability here. Use private vulnerability reporting.
+        See SECURITY.md.
+  - type: textarea
+    id: what
+    attributes:
+      label: What is broken
+      description: One or two sentences.
+    validations:
+      required: true
+  - type: input
+    id: where
+    attributes:
+      label: Where
+      description: File path, schema $id, documentation page, or workflow name.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What the specification says, and what happens instead
+      description: Quote the line if there is one.
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact on implementers
+      description: Who breaks, and how badly.
+    validations:
+      required: false
+  - type: dropdown
+    id: priority-scope
+    attributes:
+      label: Current Priority Scope
+      description: >-
+        Read the Current Priority Scope in CONTRIBUTING.md before answering. An honest
+        "deferred" is more useful to us than a hopeful "in focus".
+      options:
+        - Feeds the runnable Guardian reference implementation
+        - Feeds the AGT interoperability benchmark
+        - Feeds conformance evidence
+        - This is deferred or out of scope and I am filing it to be tracked
+        - I am not sure
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/2-proposal.yml
+++ b/.github/ISSUE_TEMPLATE/2-proposal.yml
@@ -1,0 +1,67 @@
+name: Feature or specification proposal
+description: A new capability, hook, event, or AgBOM component.
+title: "[Proposal] "
+labels: ["type:proposal", "status:needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        Specification changes affect every downstream implementer. Open a Discussion
+        first and link it below.
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: What cannot be done today. Describe the problem, not the solution.
+    validations:
+      required: true
+  - type: textarea
+    id: wire
+    attributes:
+      label: Why the wire has to carry it
+      description: >-
+        SPEC_REVIEW_PRINCIPLES.md principle 3 is that something goes on the wire only if
+        it is lost otherwise. Make that case.
+    validations:
+      required: true
+  - type: checkboxes
+    id: constituencies
+    attributes:
+      label: Which constituencies this affects
+      description: From SPEC_REVIEW_PRINCIPLES.md principle 2.
+      options:
+        - label: Observed Agent implementers
+        - label: Guardian implementers
+        - label: Policy authors
+        - label: Auditors and incident responders
+        - label: Platform and harness vendors
+        - label: Enterprise deployers
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Including riding an existing element rather than adding one.
+    validations:
+      required: true
+  - type: input
+    id: discussion
+    attributes:
+      label: Discussion link
+      description: The Discussion thread where this was raised.
+    validations:
+      required: true
+  - type: dropdown
+    id: priority-scope
+    attributes:
+      label: Current Priority Scope
+      description: >-
+        Read the Current Priority Scope in CONTRIBUTING.md before answering. An honest
+        "deferred" is more useful to us than a hopeful "in focus".
+      options:
+        - Feeds the runnable Guardian reference implementation
+        - Feeds the AGT interoperability benchmark
+        - Feeds conformance evidence
+        - This is deferred or out of scope and I am filing it to be tracked
+        - I am not sure
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/3-reference-implementation.yml
+++ b/.github/ISSUE_TEMPLATE/3-reference-implementation.yml
@@ -1,0 +1,50 @@
+name: Reference implementation work
+description: A port to another runtime, a hardening task, or a new adapter.
+title: "[RefImpl] "
+labels: ["type:refimpl", "status:needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        This is the work the project needs most. Check the open issues labelled
+        `help wanted` before filing, since the one you want may already be accepted.
+  - type: input
+    id: target
+    attributes:
+      label: Target runtime or language
+      description: For example Python, Go, Rust, Codex, or an existing implementation to harden.
+    validations:
+      required: true
+  - type: textarea
+    id: proves
+    attributes:
+      label: What this proves
+      description: >-
+        A reference implementation earns its place by demonstrating something the
+        specification alone cannot. Say what.
+    validations:
+      required: true
+  - type: dropdown
+    id: intent
+    attributes:
+      label: Do you intend to implement this yourself
+      options:
+        - "Yes, I want this assigned to me"
+        - "No, I am proposing it for someone else"
+    validations:
+      required: true
+  - type: dropdown
+    id: priority-scope
+    attributes:
+      label: Current Priority Scope
+      description: >-
+        Read the Current Priority Scope in CONTRIBUTING.md before answering. An honest
+        "deferred" is more useful to us than a hopeful "in focus".
+      options:
+        - Feeds the runnable Guardian reference implementation
+        - Feeds the AGT interoperability benchmark
+        - Feeds conformance evidence
+        - This is deferred or out of scope and I am filing it to be tracked
+        - I am not sure
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/3-reference-implementation.yml
+++ b/.github/ISSUE_TEMPLATE/3-reference-implementation.yml
@@ -6,7 +6,7 @@ body:
   - type: markdown
     attributes:
       value: >-
-        This is the work the project needs most. Check the open issues labelled
+        This is the work the project needs most. Check the open issues labeled
         `help wanted` before filing, since the one you want may already be accepted.
   - type: input
     id: target

--- a/.github/ISSUE_TEMPLATE/4-conformance-report.yml
+++ b/.github/ISSUE_TEMPLATE/4-conformance-report.yml
@@ -1,0 +1,47 @@
+name: Conformance or dogfooding report
+description: You ran ACS against a real harness and it did not behave as specified.
+title: "[Conformance] "
+labels: ["type:conformance", "status:needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        **Stop if you found a security vulnerability.** A dogfooding run is the most
+        likely place to find one. Do not describe it here. Use private vulnerability
+        reporting: see SECURITY.md.
+  - type: textarea
+    id: setup
+    attributes:
+      label: What you ran
+      description: Harness, adapter, Guardian, versions, and configuration.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+      description: Cite the specification section that led you to expect it.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: What happened
+      description: Include the wire payload if you have it, with secrets removed.
+    validations:
+      required: true
+  - type: dropdown
+    id: priority-scope
+    attributes:
+      label: Current Priority Scope
+      description: >-
+        Read the Current Priority Scope in CONTRIBUTING.md before answering. An honest
+        "deferred" is more useful to us than a hopeful "in focus".
+      options:
+        - Feeds the runnable Guardian reference implementation
+        - Feeds the AGT interoperability benchmark
+        - Feeds conformance evidence
+        - This is deferred or out of scope and I am filing it to be tracked
+        - I am not sure
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/5-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/5-documentation.yml
@@ -1,0 +1,33 @@
+name: Documentation
+description: A page is wrong, unclear, or missing.
+title: "[Docs] "
+labels: ["type:docs", "status:needs-triage"]
+body:
+  - type: input
+    id: page
+    attributes:
+      label: Page
+      description: URL or file path.
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is wrong or missing
+    validations:
+      required: true
+  - type: dropdown
+    id: priority-scope
+    attributes:
+      label: Current Priority Scope
+      description: >-
+        Read the Current Priority Scope in CONTRIBUTING.md before answering. An honest
+        "deferred" is more useful to us than a hopeful "in focus".
+      options:
+        - Feeds the runnable Guardian reference implementation
+        - Feeds the AGT interoperability benchmark
+        - Feeds conformance evidence
+        - This is deferred or out of scope and I am filing it to be tracked
+        - I am not sure
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/6-something-else.yml
+++ b/.github/ISSUE_TEMPLATE/6-something-else.yml
@@ -1,0 +1,18 @@
+name: Something else
+description: >-
+  A structural finding, a question the other forms do not fit, or an idea that does not
+  have a shape yet. Nothing here is required except the description.
+title: ""
+labels: ["type:proposal", "status:needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        The other forms exist to make triage fast. This one exists because the most
+        valuable contributions rarely fit a form. Tell us what you found.
+  - type: textarea
+    id: what
+    attributes:
+      label: What you want to tell us
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,11 @@
 # Routes people away from filing security reports as public issues, which is
 # the single most common way a coordinated disclosure gets blown.
+#
+# Blank issues are off because a form is what applies the type: and
+# status:needs-triage labels that triage depends on. The "Something else" form is the
+# open door that keeps this from turning away a finding that fits no template.
 
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Report a security vulnerability
     url: https://github.com/GenAI-Security-Project/agent-control-standard/security/advisories/new

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@
 # keeps a poisoned version from landing in a PR that looks routine.
 
 version: 2
+# No target-branch key. Dependabot follows the default branch, which is `integration`,
+# so both routine and security updates land there and never meet the base-branch guard.
+# Setting target-branch would make this depend on undocumented security-update targeting
+# behavior for no benefit.
 updates:
   # GitHub Actions run with write access to the repository. Actions are pinned
   # to commit SHAs in the workflows, and Dependabot understands SHA pins and

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,9 +2,28 @@
 
 <!-- One or two sentences. What does this PR do and why? -->
 
+## Which issue does this implement
+
+Closes #
+
+<!-- A change that alters behavior, normative text, or adds code needs an issue carrying
+     `status:accepted`. If yours is not accepted yet, open the PR anyway. It will wait
+     rather than be closed. See Current Priority Scope in CONTRIBUTING.md. -->
+
+- [ ] This is an editorial correction (typo, grammar, link, formatting) with no change in
+      meaning, so it needs no issue
+
+## Base branch
+
+- [ ] `integration`, because this touches the specification, schemas, a reference
+      implementation, an adapter, tests, or CI
+- [ ] `main`, because every changed path is on the documentation lane allowlist in
+      CONTRIBUTING.md
+
 ## Type of change
 
 - [ ] Specification change (schema, hooks, events, AgBOM)
+- [ ] Reference implementation or adapter
 - [ ] Documentation
 - [ ] Tooling or CI
 - [ ] Governance (licensing, security policy, contributor docs)
@@ -19,11 +38,19 @@
 
 **Breaking for implementers?** <!-- yes or no, and what breaks -->
 
+## I tested this
+
+- [ ] I synced my branch with the base branch before opening this
+- [ ] `uv run pytest -v` passes on my machine
+- [ ] `uv run mkdocs build --strict` passes on my machine
+
+<!-- These three are the difference between a review and a debugging session. A PR that
+     has not been run is not ready for someone else's afternoon. -->
+
 ## Checklist
 
 - [ ] Commits are signed off with `git commit -s` (required by the DCO)
 - [ ] Prose follows [STYLE.md](../STYLE.md)
-- [ ] `uv run mkdocs build --strict` passes
 - [ ] No secrets, tokens, or internal URLs in the diff
 
 ## Security

--- a/.github/workflows/monitor-pages.yml
+++ b/.github/workflows/monitor-pages.yml
@@ -21,6 +21,13 @@ jobs:
     steps:
       - name: Check out the repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # A scheduled workflow runs from the default branch. Once the default moves to
+          # integration, checking out the default here would verify integration's schema
+          # set against a site that publishes from main, failing every six hours between
+          # promotions. The site publishes from main regardless of which branch is
+          # default, so this must always check out main.
+          ref: main
 
       - name: Verify the published schemas still resolve
         env:

--- a/.github/workflows/open-promotion.yml
+++ b/.github/workflows/open-promotion.yml
@@ -30,6 +30,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          # integration does not exist until the branch migration runs. Exit quietly rather
+          # than failing a scheduled job on a branch nobody has created yet.
+          git rev-parse --verify origin/integration >/dev/null 2>&1 || { echo "integration does not exist yet."; exit 0; }
           AHEAD="$(git rev-list --count origin/main..origin/integration)"
           if [ "$AHEAD" -eq 0 ]; then
             echo "integration is not ahead of main. Nothing to promote."

--- a/.github/workflows/open-promotion.yml
+++ b/.github/workflows/open-promotion.yml
@@ -1,0 +1,44 @@
+# Opens the weekly promotion pull request from integration to main.
+#
+# A three-tier branching model pays its whole cost up front and returns nothing until a
+# promotion happens. Leaving promotion to memory is how integration accrues specification
+# work while main keeps publishing schemas nobody is reading.
+name: Open promotion pull request
+
+on:
+  schedule:
+    # 13:00 UTC Thursday, the morning of the weekly call.
+    - cron: "0 13 * * 4"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Open the promotion pull request if integration is ahead
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          AHEAD="$(git rev-list --count origin/main..origin/integration)"
+          if [ "$AHEAD" -eq 0 ]; then
+            echo "integration is not ahead of main. Nothing to promote."
+            exit 0
+          fi
+          if [ "$(gh pr list --base main --head integration --state open --json number --jq 'length')" -gt 0 ]; then
+            echo "A promotion pull request is already open."
+            exit 0
+          fi
+          gh pr create --base main --head integration \
+            --title "Promote integration to main" \
+            --body "${AHEAD} commit(s) ahead. Merging publishes the site and every schema \$id URI. Merge with a merge commit, not a squash: squashing flattens the specification history that makes a schema change reviewable later."

--- a/.github/workflows/pr-base-guard.yml
+++ b/.github/workflows/pr-base-guard.yml
@@ -1,0 +1,49 @@
+# Keeps specification and code changes off the branch that publishes on merge.
+#
+# The job id below is the check run name the protect-main ruleset requires. Renaming the
+# job without renaming the required check leaves a required status check that never
+# reports, which blocks every pull request to main permanently.
+name: PR base guard
+
+on:
+  pull_request:
+    branches: ["main"]
+
+permissions: {}
+
+concurrency:
+  group: pr-base-guard-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  base-branch-guard:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Both endpoints of the diff have to be present to compute a merge base.
+          fetch-depth: 0
+
+      - name: List the changed paths
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Three-dot compares against the merge base, so commits that landed on the
+          # base branch after this pull request opened do not count as its changes.
+          git diff --name-only "${BASE_SHA}...${HEAD_SHA}" > changed.txt
+          cat changed.txt
+
+      - name: Enforce the documentation lane
+        env:
+          # Passed through the environment rather than interpolated into the shell. A
+          # head ref is contributor-controlled text and ${{ }} inside run: executes.
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+        run: python3 tools/base_branch_guard.py changed.txt

--- a/.github/workflows/pr-intake.yml
+++ b/.github/workflows/pr-intake.yml
@@ -1,0 +1,65 @@
+# Tells a contributor why their pull request is waiting, and labels it so the queue is
+# visible.
+#
+# pull_request_target is used deliberately: GITHUB_TOKEN is read-only on a pull_request
+# event from a fork, and every external contribution is a fork. That trigger runs with
+# repository write scope against the base branch, so this workflow checks out no code,
+# runs no contributor-supplied script, and reads the pull request body from the event
+# payload as data.
+name: PR intake
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened]
+
+permissions: {}
+
+concurrency:
+  group: pr-intake-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: read
+    steps:
+      - name: Check whether a referenced issue is accepted
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+          # Issue numbers are extracted from the body text, which is untrusted input. It
+          # is matched against a digit pattern and never evaluated.
+          NUMBERS="$(printf '%s' "${PR_BODY:-}" | grep -oE '#[0-9]+' | tr -d '#' | sort -u || true)"
+          if printf '%s' "${PR_BODY:-}" | grep -qiE '^\s*-\s*\[x\]\s*This is an editorial correction'; then
+            echo "Declared editorial. No issue required."
+            exit 0
+          fi
+          # The `edited` trigger fires every time anyone touches the body, so without
+          # this the queue comment gets reposted on every edit. The Actions bot reports
+          # as `github-actions` in some payloads and `github-actions[bot]` in others, so
+          # the check is a prefix match rather than an exact one.
+          if gh pr view "$PR_NUMBER" --repo "$REPO" --json comments \
+             --jq '[.comments[] | select(.author.login | startswith("github-actions"))] | length' \
+             | grep -qv '^0$'; then
+            echo "Already commented on this pull request."
+            exit 0
+          fi
+          for n in $NUMBERS; do
+            if gh issue view "$n" --repo "$REPO" --json labels \
+               --jq '.labels[].name' 2>/dev/null | grep -qx 'status:accepted'; then
+              echo "Issue #$n is accepted."
+              exit 0
+            fi
+          done
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label 'status:needs-triage'
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "Thanks for this. It is queued rather than ignored.
+
+          This pull request does not reference an issue carrying \`status:accepted\`, so a maintainer has not looked at it yet and will not until the underlying issue is triaged. Nothing here is rejected. See [Current Priority Scope](https://github.com/GenAI-Security-Project/agent-control-standard/blob/main/CONTRIBUTING.md#current-priority-scope) for what the project is working on, and [\`help wanted\`](https://github.com/GenAI-Security-Project/agent-control-standard/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) for work that is already accepted.
+
+          If this is an editorial correction, tick that box in the description and this comment stops applying."

--- a/.github/workflows/scope-review.yml
+++ b/.github/workflows/scope-review.yml
@@ -1,0 +1,49 @@
+# Opens an issue when the Current Priority Scope review date passes.
+#
+# It opens an issue rather than failing a build. A stale scope is a governance problem,
+# and blocking a documentation deploy on one helps nobody.
+name: Scope review reminder
+
+on:
+  schedule:
+    - cron: "0 14 * * 1"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  remind:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Open a review issue if the date has passed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # The date is read from CONTRIBUTING.md so the document stays the single source.
+          DUE="$(grep -oE 'Next review [A-Z][a-z]+ [0-9]{1,2}, [0-9]{4}' CONTRIBUTING.md \
+                 | head -1 | sed 's/^Next review //')"
+          if [ -z "$DUE" ]; then
+            echo "::error file=CONTRIBUTING.md::No 'Next review <date>' line found"
+            exit 1
+          fi
+          DUE_EPOCH="$(date -u -d "$DUE" +%s)"
+          NOW_EPOCH="$(date -u +%s)"
+          if [ "$NOW_EPOCH" -lt "$DUE_EPOCH" ]; then
+            echo "Scope review not due until $DUE."
+            exit 0
+          fi
+          TITLE="Review the Current Priority Scope (was due $DUE)"
+          if [ "$(gh issue list --state open --search "$TITLE in:title" --json number --jq 'length')" -gt 0 ]; then
+            echo "Reminder already open."
+            exit 0
+          fi
+          gh issue create --title "$TITLE" \
+            --label 'status:needs-triage' \
+            --body "The Current Priority Scope in CONTRIBUTING.md passed its review date of $DUE. Confirm what is still in focus, move what has shipped, and set the next review date. This is a standing item for the weekly call."

--- a/.github/workflows/sync-integration.yml
+++ b/.github/workflows/sync-integration.yml
@@ -1,0 +1,46 @@
+# Keeps integration current with main, so a promotion pull request stays conflict-free.
+#
+# This opens a pull request rather than pushing. The protect-integration ruleset requires
+# pull requests and blocks non-fast-forward updates, and GITHUB_TOKEN is not a bypass
+# actor, so a push here would fail on every run.
+name: Sync integration from main
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: sync-integration
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Open or update the sync pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if git merge-base --is-ancestor origin/main origin/integration; then
+            echo "integration already contains main. Nothing to sync."
+            exit 0
+          fi
+          if [ "$(gh pr list --base integration --head main --state open --json number --jq 'length')" -gt 0 ]; then
+            echo "A sync pull request is already open."
+            exit 0
+          fi
+          gh pr create --base integration --head main \
+            --title "Sync integration from main" \
+            --body "Documentation landed on main. This carries it to integration so the next promotion does not conflict. The content already passed review on main."

--- a/.github/workflows/sync-integration.yml
+++ b/.github/workflows/sync-integration.yml
@@ -33,8 +33,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          if git merge-base --is-ancestor origin/main origin/integration; then
-            echo "integration already contains main. Nothing to sync."
+          # integration does not exist until the branch migration runs. Exit quietly rather
+          # than failing a scheduled job on a branch nobody has created yet.
+          git rev-parse --verify origin/integration >/dev/null 2>&1 || { echo "integration does not exist yet."; exit 0; }
+          # protect-integration allows squash and rebase merges only. A squash of the sync
+          # pull request never makes main an ancestor of integration, so an ancestry check
+          # is false forever even once the two trees hold identical content. Compare content
+          # instead.
+          if git diff --quiet origin/integration origin/main; then
+            echo "integration already matches main. Nothing to sync."
             exit 0
           fi
           if [ "$(gh pr list --base integration --head main --state open --json number --jq 'length')" -gt 0 ]; then

--- a/.github/workflows/sync_version.yml
+++ b/.github/workflows/sync_version.yml
@@ -1,12 +1,12 @@
 # Synchronizes the version in version.txt across the project files.
-# Triggers on a push to version.txt on main, or manually.
+# Triggers on a push to version.txt on integration, or manually.
 name: Sync Version
 
 on:
   push:
     paths:
       - 'version.txt'
-    branches: ["main"]
+    branches: ["integration"]
   workflow_dispatch:
 
 # Deny by default. The one job below grants itself only what it needs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,72 @@ We're building trustworthy AI agents together. Your contributions make the futur
 
 Search existing issues and pull requests to avoid duplicating efforts.
 
+## Current Priority Scope
+
+Reviewed at each milestone. Current window: Day 0 to Day 30. Next review October 9, 2026.
+
+The project has one committed outcome:
+
+> A runnable Guardian Agent reference implementation, benchmarked for interoperability
+> against Microsoft Agent Governance Toolkit, in the hands of external evaluators within
+> ninety days of the September 10, 2026 kick-off. Everything else either feeds that
+> outcome or gets deferred.
+
+Every issue and every pull request is accepted against that sentence. This section is the
+only place that scope is stated, so if something here disagrees with a form, a template,
+or a comment, this wins.
+
+**In focus.** Work that feeds the runnable Guardian, the interoperability benchmark, or
+the conformance evidence that makes either credible:
+
+- The mandatory floor decision in PR #21, which gates everything behind it
+- The Claude Code, Cursor, and NVIDIA NAT adapters in PR #22
+- The AGT reference implementation in PR #60
+- Ports of that reference implementation to other runtimes: Python, Go, Rust, Codex
+- Production-hardening it, including span batching and OpenTelemetry collection
+- Resolving the fail-open default, which issues #32 and #37 attack from opposite ends
+- The ACS-Core conformance claim template
+- The requirement ledger and behavioral tests in milestone #33
+- Closing the Cursor file-read gap
+- Conformance and dogfooding reports that document where ACS fails in practice
+
+**Deferred to v0.2.0.** Real work, tracked, landing after Day 90: async and composition,
+streaming, batching semantics, recursive ask, quorum, multi-tenant isolation, the Cedar
+binding, and AgBOM federation across A2A peers. Negative conformance vectors sit here
+too, in #53.
+
+One distinction, because it will otherwise get argued in a pull request. *Batching
+semantics in the specification* is deferred. *Batching in the reference implementation*
+is in focus, because it is exactly the production-hardening the project asked for. The
+two share a word and nothing else.
+
+**Out of scope.** What ACS leaves to deployments by design: the policy engine, the
+signature algorithm, the transport, the authentication mechanism, and the policy content.
+The specification is opinionated on the contract and permissive on the implementation.
+That is a position, not a gap waiting to be filled.
+
+A proposal that is deferred or out of scope is still worth filing. It gets a label and a
+tracking issue rather than a close, because a finding the project cannot act on this
+quarter is not a finding without value.
+
+## How work gets accepted
+
+Anyone may open an issue. Only an issue carrying `status:accepted` enters the backlog,
+and only a maintainer applies that label.
+
+A pull request that changes behavior, alters normative text, or adds code references an
+accepted issue. An editorial correction does not, wherever it lands: a typo, a grammar
+fix, a broken link, or a formatting repair that leaves the meaning untouched needs no
+issue.
+
+If you open a pull request against an issue that is not accepted yet, it will not be
+closed and it will not be reviewed. It waits, and a comment will say so. Start from an
+issue labeled `help wanted` if you want work that is already accepted.
+
+Maintainers apply `scope:`, `priority:`, `workstream:`, and `status:accepted`. No issue
+form can apply them, which is what makes the rule hold rather than depend on everyone
+remembering it.
+
 ## Code of Conduct
 
 This project follows our [Code of Conduct](./CODE_OF_CONDUCT.md). By participating, you agree to uphold it.
@@ -42,26 +108,61 @@ All submissions go through GitHub pull request review. See [GitHub's PR guide](h
 ## Development Process
 
 1. **Fork the repository** and clone your fork
-2. **Create a feature branch.** Use `feature/<short-description>` or `fix/<short-description>`
+2. **Branch from `integration`.** Use `spec/`, `refimpl/`, `fix/`, or `docs/` followed by
+   a short description
 3. **Make your changes** following the style guide
-4. **Sign your commits** with `git commit -s` (required by the DCO below)
-5. **Open a pull request** against `main`
-6. **Address review feedback** to land your change
+4. **Sync with `integration` and run the guards** before you open anything. `uv run
+   pytest -v` and `uv run mkdocs build --strict` both have to pass on your machine
+5. **Sign your commits** with `git commit -s` (required by the DCO below)
+6. **Open a pull request against `integration`**
+7. **Address review feedback** to land your change
 
-For changes to the spec itself (`acs_schema.json`, hooks, events), open a [Discussion](https://github.com/GenAI-Security-Project/agent-control-standard/discussions) before submitting a PR. These affect downstream implementers and warrant a longer conversation.
+`integration` is the default branch, so a pull request opened from the GitHub interface
+already targets it. `main` publishes the site and all 44 schema `$id` URIs on merge, so
+it takes only two kinds of change: a promotion from `integration`, and an editorial
+change to a path on the allowlist below. A guard enforces this and will tell you to
+retarget if you get it wrong.
 
-Commits land under human authorship. Many of us write with AI assistance, and the project takes no position on which tools you use. The sign-off is what matters here. The DCO below is a certification a person makes about the origin of the code, and only a person can make it. Keep your `Signed-off-by` line, and leave AI tools out of the commit trailers. If a `Co-Authored-By` naming a model reaches a pull request, a maintainer drops it when the pull request is squashed, and your authorship and sign-off carry through unchanged.
+Paths that may target `main` directly: `docs/topics/`, `design/`, `docs/README.md`,
+`README.md`, `CONTRIBUTORS.md`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `GOVERNANCE.md`,
+`SECURITY.md`, `STYLE.md`, `LICENSING.md`, and `NOTICE`. Everything else goes to
+`integration`, including `docs/spec/`, `docs/concepts/`, `docs/identity/`, `mkdocs.yml`,
+`overrides/`, `landing/`, `docs/stylesheets/`, and `docs/assets/`.
+
+For changes to the spec itself (`acs_schema.json`, hooks, events), open a
+[Discussion](https://github.com/GenAI-Security-Project/agent-control-standard/discussions)
+before submitting a PR. These affect downstream implementers and warrant a longer
+conversation.
+
+## Authorship and AI assistance
+
+Commits land under human authorship. The DCO below is a certification about the origin of
+code, and only a person can make one, so every commit carries a `Signed-off-by` line
+naming a human who takes responsibility for what the commit contains. That requirement
+does not move.
+
+The rest of the trailers are your call. Many contributors here write with AI assistance.
+If you want to record that with a `Co-Authored-By` trailer naming the tool, keep it. If
+you would rather not, leave it off. Maintainers will not add one and will not remove one,
+and its presence has no effect on how a change is reviewed.
+
+A trailer naming a model certifies nothing and moves no responsibility. The human on the
+`Signed-off-by` line answers for the change either way. Some employers require their
+people to disclose AI assistance, and a visible trailer is the simplest way to satisfy
+that. ACS is also a standard about agent provenance, and a project built on the premise
+that you should be able to see what an agent did has no business erasing the record of
+what an agent did to its own commits.
 
 ## What We Need
 
-**High Priority:**
-Look for unassigned [Open Issues](https://github.com/GenAI-Security-Project/agent-control-standard/issues).
+Start with [issues labeled `help wanted`](https://github.com/GenAI-Security-Project/agent-control-standard/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22).
+Every one of them is already accepted, which means you can open a pull request against it
+without waiting on triage.
 
-**Always Welcome:**
-- Documentation improvements
-- Real-world use case examples
-- Security analysis and feedback
-- Performance optimizations
+The highest-value contribution right now is running ACS against a real harness and
+documenting where it fails. Install the reference implementation, wire it to a coding
+agent, and file a conformance report when the behavior and the specification disagree.
+That is worth more to this project than a patch nobody asked for.
 
 ## Release Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,8 +65,10 @@ fix, a broken link, or a formatting repair that leaves the meaning untouched nee
 issue.
 
 If you open a pull request against an issue that is not accepted yet, it will not be
-closed and it will not be reviewed. It waits, and a comment will say so. Start from an
-issue labeled `help wanted` if you want work that is already accepted.
+reviewed and nothing about it is rejected. It waits, and a comment will say so. A pull
+request that sits untriaged for a long time may be closed with an invitation to reopen
+once its issue is accepted. Start from an issue labeled `help wanted` if you want work
+that is already accepted.
 
 Maintainers apply `scope:`, `priority:`, `workstream:`, and `status:accepted`. No issue
 form can apply them, which is what makes the rule hold rather than depend on everyone

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -20,6 +20,22 @@ Each workstream owns a slice of the standard and runs its own review. Two leads 
 | Outreach | Eva Benn ([@evabenn](https://github.com/evabenn)), Aruneesh Salhotra ([@aruneeshsalhotra](https://github.com/aruneeshsalhotra)) |
 | Spec | Bar Kaduri ([@bar-capsule](https://github.com/bar-capsule)), Ariel Fogel ([@afogel](https://github.com/afogel)) |
 
+## Triage authority
+
+Workstream leads and the project lead apply the decision labels: `scope:`, `priority:`,
+`workstream:`, and `status:accepted`. Nobody else does, and no issue form can.
+
+Minimum triage on a new issue is two labels, `scope:` and `status:`. `priority:` and
+`workstream:` are enrichment applied to accepted work. Requiring four decisions per issue
+is how a taxonomy stops getting used in month two.
+
+`priority:P0` is reserved for work on the serial chain the Strategic Adoption Plan names:
+the mandatory floor decision, the adapters, the installable Guardian, and the
+interoperability benchmark. It does not mean important.
+
+Triage runs on the weekly call. Promotion from `integration` to `main` is a standing item
+on the same call, and the project lead owns merging it.
+
 ## Origins
 
 Michael Bargury ([@mbrg](https://github.com/mbrg)) and Ory Segal ([@oorryy](https://github.com/oorryy)) created ACS. Both remain project leaders.

--- a/design/2026-09-09-contribution-governance-design.md
+++ b/design/2026-09-09-contribution-governance-design.md
@@ -128,7 +128,7 @@ Three things then argue for `integration`. Dependabot targets the default branch
 key at all, which removes a dependency on undocumented security-update targeting behavior
 rather than betting on it. Mistargeting fails in the safe direction, because a documentation
 pull request that lands on `integration` is merely slower while a specification pull request
-that lands on `main` shows a first-time contributor a red failed check. And a contributor who
+that lands on `main` shows a first-time contributor a red failed check. A contributor who
 does nothing but accept GitHub's default is doing the right thing, which is the only version
 of a rule that survives a hundred new people.
 
@@ -490,7 +490,7 @@ contributions Track 1 needs. Ariel's invitation in the sync was open: if somebod
 open a reference implementation against Codex, have at it. A gate requiring an accepted
 issue turns that invitation into a queue wait unless the accepted issue already exists.
 
-So maintainers file them before the kick-off. Each carries `scope:in-focus`,
+Maintainers therefore file them before the kick-off. Each carries `scope:in-focus`,
 `status:accepted`, `help wanted`, a workstream, and a priority:
 
 1. Port the AGT reference implementation to Python

--- a/design/2026-09-09-contribution-governance-design.md
+++ b/design/2026-09-09-contribution-governance-design.md
@@ -585,7 +585,7 @@ regression if run out of order.
 3. **Create `integration` from `main`.** The two branches are identical at this moment, which
    is what makes the next step free.
 4. **Retarget the remaining pull requests.** #63, #24, #22, and #60 move to `integration` if
-   still open. #20, the FAQ, may stay on `main`. Because the branches are identical, no diff
+   still open, and so does #20. Because the branches are identical, no diff
    changes and no contributor redoes any work.
 5. **Move the default branch to `integration`.** Last, after the protection is pinned and the
    retargets are done.

--- a/design/2026-09-09-contribution-governance-design.md
+++ b/design/2026-09-09-contribution-governance-design.md
@@ -1,9 +1,20 @@
 # Contribution governance for the OWASP re-launch
 
-Version: 1.0
+Version: 1.1
 Owner: ACS project lead
 Date: 2026-09-09
 Status: design, approved for planning
+
+An adversarial premortem ran against version 1.0 and refuted five of its decisions. The
+default branch moved to `integration` once Dependabot's targeting made the original
+recommendation a bet on undocumented behavior. Required approvals on `main` stayed at one
+rather than rising to two, because doubling the cost of promotion would have throttled the
+operation the whole model exists to serve. The acceptance gate moved off base-branch
+membership and onto change substance, after the security narrowing of the documentation lane
+turned out to have widened the gate as a side effect. A sixth open-ended issue form was added,
+because turning off blank issues would have closed the door the project's strongest outside
+contribution came through. Promotion and integration sync both gained machine triggers, since
+each was otherwise nobody's job and one of them could not have worked at all.
 
 The OWASP re-launch kick-off runs Thursday, September 10, 2026. The core team sync on
 September 8 named the problem plainly: many people want to contribute, and the project has
@@ -97,19 +108,32 @@ Four kinds of branch.
 
 | Branch | Receives | Publishes |
 |---|---|---|
-| `main` | docs-lane pull requests, promotion pull requests | site, all 44 schema `$id` URIs |
+| `main` | editorial pull requests on allowlisted paths, promotion pull requests | site, all 44 schema `$id` URIs |
 | `integration` | specification, schemas, reference implementations, adapters, tests, CI | nothing |
 | `release/vX.Y.Z` | stabilization for a tagged specification version | nothing until merged |
 | fork branches | contributor work | nothing |
 
-`main` stays the repository default. This is deliberate and runs against the sync's
-shorthand that all pull requests target `integration`, so the reasoning matters. The
-`protect-main` ruleset currently keys its condition on `~DEFAULT_BRANCH`. Moving the default
-to `integration` transfers that protection to `integration` and leaves `main` bare, which is
-a silent security regression rather than a visible one. Keeping `main` as default also gives
-the documentation lane, which will carry the most contributors and the least GitHub
-fluency, the path with no base-branch step, while a mistargeted specification pull request
-is caught by a guard at no maintainer cost.
+`integration` becomes the repository default, which matches the sync's instruction that all
+pull requests target it. Version 1.0 of this design recommended the opposite and the
+premortem reversed it, so the reasoning is recorded rather than assumed.
+
+The objection to moving the default was that `protect-main` keys its condition on
+`~DEFAULT_BRANCH`, so moving the default would transfer that protection to `integration` and
+leave `main` bare. That is a real hazard and it is closed independently, by pinning the
+condition to the literal `refs/heads/main` before the default moves. Order matters: pin
+first, then move.
+
+Three things then argue for `integration`. Dependabot targets the default branch, and with
+`integration` as default both routine and security updates land there with no `target-branch`
+key at all, which removes a dependency on undocumented security-update targeting behavior
+rather than betting on it. Mistargeting fails in the safe direction, because a documentation
+pull request that lands on `integration` is merely slower while a specification pull request
+that lands on `main` shows a first-time contributor a red failed check. And a contributor who
+does nothing but accept GitHub's default is doing the right thing, which is the only version
+of a rule that survives a hundred new people.
+
+The cost is real and accepted: `main` is the branch that publishes the site, and it is no
+longer what a visitor lands on or what `git clone` checks out.
 
 Treating the specification as code is the sync's other instruction, and it decides the
 allowlist below.
@@ -172,28 +196,49 @@ merge forever, so it runs and passes rather than skipping. A mixed diff carrying
 documentation and specification fails, which forces the split instead of letting the
 specification ride in on a documentation change.
 
-Two automated producers currently open pull requests against the default branch and touch
-paths outside the allowlist. Dependabot gets `target-branch: "integration"` in
-`.github/dependabot.yml`. `sync_version.yml` moves its trigger from a push to `version.txt`
-on `main` to the same push on `integration`. Neither gets an exemption in the guard, because
-an exemption keyed on an actor is a hole an actor can be impersonated through.
+**The required status check context is the job name, not the workflow name.** GitHub matches
+a required check against the check run, so a ruleset requiring `base-branch-guard` while the
+workflow declares `jobs: { guard: ... }` never matches, never reports, and leaves every pull
+request to `main` permanently unmergeable. The job id is therefore fixed at
+`base-branch-guard`, and the ruleset requires that exact string. The two are one value and
+are changed together or not at all.
+
+Automated producers need no special handling once `integration` is the default branch.
+Dependabot targets the default branch, so both routine and security updates land on
+`integration` with no `target-branch` key in `.github/dependabot.yml` and no guard
+interaction at all. `sync_version.yml` moves its trigger from a push to `version.txt` on
+`main` to the same push on `integration`, and it already opens a pull request rather than
+pushing. No actor-keyed exemption exists anywhere in the guard, because an exemption keyed
+on an actor is a hole an actor can be impersonated through.
 
 ### Promotion
 
-A promotion is a pull request from `integration` to `main`, opened by a maintainer, merged
-with a merge commit rather than a squash. Squashing a promotion flattens every specification
-commit into one and destroys the history that makes a schema change reviewable after the
-fact. `protect-main` currently allows only squash and rebase, so `merge` gets added.
+A promotion is a pull request from `integration` to `main`, merged with a merge commit
+rather than a squash. Squashing a promotion flattens every specification commit into one and
+destroys the history that makes a schema change reviewable after the fact. `protect-main`
+currently allows only squash and rebase, so `merge` gets added.
 
 Promotion is when the 44 schema URIs change. That is a property worth keeping: the URIs are
 a machine-consumed contract, and batching their changes into a deliberate promotion is
 better than republishing on every specification merge.
 
-`integration` needs to stay current with `main`, since `main` receives documentation commits
-independently. `.github/workflows/sync-integration.yml` runs on every push to `main` and
-merges `main` into `integration`, so a promotion pull request stays conflict-free. It runs
-on push rather than on a schedule because the divergence starts at the merge, and a nightly
-job would leave a day of drift for a promotion to collide with.
+**Promotion needs an owner and a trigger, or it does not happen.** This is the failure mode
+that costs the three-tier model everything and returns nothing: `integration` accrues
+specification work, `main` keeps publishing schemas that no longer match what contributors
+are reading, and the divergence is nobody's assigned problem. Two mechanisms close it.
+`.github/workflows/open-promotion.yml` runs weekly, the morning of the call, and opens or
+updates a promotion pull request whenever `integration` is ahead of `main`. A machine opening
+it means the decision in front of the core team is whether to merge rather than whether to
+remember. The project lead owns merging it, and promotion is a standing item on the weekly
+call agenda.
+
+`integration` also needs to stay current with `main`, since `main` receives documentation
+commits independently. `.github/workflows/sync-integration.yml` runs on every push to `main`
+and **opens a pull request** merging `main` into `integration`. It cannot push directly:
+`protect-integration` requires pull requests and blocks non-fast-forward updates, and
+`GITHUB_TOKEN` is not a bypass actor, so a workflow that pushed would fail on every run. The
+sync pull request is the one place where an automatic merge is safe to enable, because its
+content already passed review on `main`.
 
 ## Labels
 
@@ -211,6 +256,13 @@ Labels become prefixed axes rather than a flat pile, and the axes split by who s
 
 `priority:P0` is reserved for the four links in the plan's serial chain, so the label means
 something narrower than "important."
+
+**Minimum viable triage is two labels: `scope:` and `status:`.** Five axes means five
+decisions per issue, and under real volume a triager who owes five decisions makes none, so
+the backlog fills with issues carrying `status:needs-triage` and nothing else. `priority:`
+and `workstream:` are enrichment applied to accepted work, not entry requirements.
+Recording that here is the difference between a taxonomy that gets used and one that gets
+abandoned in month two.
 
 Dates live in GitHub Milestones rather than labels. Day 14 through Day 90 become milestones
 carrying the plan's committed outcomes as their descriptions, which gives the weekly call a
@@ -261,7 +313,7 @@ those four is unused before deleting rather than assuming it from a listing.
 `blank_issues_enabled` moves to `false`. Every issue arrives through a form, which is what
 makes automatic `type:` and `status:needs-triage` labeling reliable.
 
-Five forms, each with a distinct triage path:
+Six forms, each with a distinct triage path:
 
 1. **Bug report.** Something is broken: a schema error, a specification defect, the site, CI,
    or tooling. Fields cover what is broken, where, what the specification says, and the
@@ -278,6 +330,17 @@ Five forms, each with a distinct triage path:
    redirect to private vulnerability reporting, because this is the form most likely to
    surface a security gap.
 5. **Documentation.** The low-friction lane. Page, what is wrong or missing.
+6. **Something else.** One open text field and nothing else required.
+
+The sixth form is the most important one in the list and the easiest to leave out. The plan
+credits the strongest technical contribution the project has ever received from outside as
+the finding that tool declarations carry no integrity binding, so a same-version redefinition
+is invisible to dynamic inspection. That finding fits none of the other five. Turning
+off blank issues without providing an open door means the next contribution of that shape
+either goes to Discussions, where it gets a fraction of the attention, or does not get filed.
+That loss is undetectable, which is precisely why it has to be designed against rather than
+watched for. The form carries `type:proposal` and `status:needs-triage` and asks nothing
+else.
 
 Every form ends with the same required dropdown asking which part of the Current Priority
 Scope the work serves, including an honest option for "this is deferred or out of scope and
@@ -304,10 +367,22 @@ each carrying the plan's committed outcome as its description.
 
 ## Pull request gate
 
-A pull request that touches specification or code references an issue carrying
-`status:accepted`. A documentation-lane pull request to `main` needs no issue. The base
-branch therefore tells a reviewer which rule applies, which is the property that makes the
-gate cheap to explain.
+The gate keys on what a change *does*, not on which branch it targets. A pull request that
+changes behavior, alters normative text, or adds code references an issue carrying
+`status:accepted`. An editorial correction does not, wherever it lands: a typo, a grammar
+fix, a broken link, or a formatting repair that leaves the meaning untouched needs no issue.
+
+Version 1.0 keyed this on the documentation lane instead, and the premortem found that the
+security narrowing of that lane had silently widened the gate. Once `docs/concepts/**` moved
+to `integration` for good reasons, a one-word typo fix in a concepts page inherited the
+requirement for an accepted issue, and a first-time contributor fixing a spelling mistake
+would have hit a governance process. A security fix should not become a contribution
+barrier by side effect, so substance decides the gate and the base branch decides only the
+branch.
+
+The pull request template carries this as a single checkbox declaring the change editorial.
+Checking it falsely is visible in the diff and costs the contributor their credibility,
+which is the right enforcement for something this small.
 
 The important question is what happens to a pull request whose issue is filed but not yet
 accepted. It is neither closed nor reviewed. Closing destroys work and reads as hostile.
@@ -323,6 +398,21 @@ a base branch is a mechanical error with one correct answer and belongs in a req
 check. Missing acceptance is a queue state that resolves on its own, and turning it into a
 red required check would make the gate feel like a rejection.
 
+The trigger is `pull_request_target`, not `pull_request`. On a `pull_request` event from a
+fork, which is every external contribution, `GITHUB_TOKEN` is read-only and the workflow
+cannot apply a label or post a comment. `pull_request_target` is the privilege-escalation
+surface CODEOWNERS guards `.github/` against, so the workflow is written to give the
+escalation nothing to reach: it checks out no code, runs no contributor-supplied script, and
+declares `permissions: { pull-requests: write, issues: read }` and nothing more. It reads the
+pull request body through the event payload and treats it as data.
+
+**The gate needs a drain, not only an intake.** A pull request that is neither closed nor
+reviewed accumulates, and in six months a queue of stale submissions each carrying a polite
+bot comment costs more maintainer attention than reviewing them would have. A pull request
+carrying `status:needs-triage` with no maintainer activity for thirty days is closed with a
+comment naming the issue it needs accepted and an explicit invitation to reopen once that
+happens. Closing with a reopen path is courteous. Leaving it open forever is not.
+
 The pull request template changes in four ways. It asks which issue the work implements and
 states the documentation-lane exemption inline. It asks the contributor to confirm they
 synced their branch and ran the guards, which is Helen's requirement from the sync and the
@@ -333,17 +423,29 @@ the existing specification, DCO, style, and security sections, which are already
 
 ### Rulesets
 
-`protect-main` is rewritten and hardened. Its condition moves from `~DEFAULT_BRANCH` to the
-literal `refs/heads/main`, which removes the silent-failure mode where a future default
-change unprotects it. Required approvals rise from one to two. Required status checks gain
-the base-branch guard alongside `test` and `build`. Allowed merge methods gain `merge` for
-promotions. Deletion and non-fast-forward protection stay.
+`protect-main` is rewritten. Its condition moves from `~DEFAULT_BRANCH` to the literal
+`refs/heads/main`, which both removes the silent-failure mode where a future default change
+unprotects it and is the precondition for moving the default to `integration` at all.
+Required status checks gain `base-branch-guard` alongside `test` and `build`, using the exact
+job id. Allowed merge methods gain `merge` for promotions. Deletion and non-fast-forward
+protection stay.
 
-One honest limitation. The sync's phrasing was that nobody except a few key people can ever
-merge into `main`. GitHub rulesets do not offer a direct "only these accounts may merge a
-pull request" control, so this design approximates it with two required approvals plus the
-existing CODEOWNERS requirement. Implementation verifies whether the current ruleset schema
-exposes a stronger restriction before settling for the approximation.
+**Required approvals stay at one.** Version 1.0 raised them to two, and the premortem
+rejected that. Promotion is the operation the entire three-tier model depends on, the plan's
+risk register already names review capacity as thin, and three CODEOWNERS entries are inert
+pending invitation acceptance. Doubling the approval cost of the one operation that
+publishes would have throttled publication in the name of protecting it. What actually
+hardens `main` is that only promotion pull requests and editorial changes reach it, every
+path on it carries a CODEOWNERS requirement, and the guard is a required check.
+
+One limitation, now verified rather than assumed. The sync's phrasing was that nobody except
+a few key people can ever merge into `main`. GitHub rulesets have no rule that restricts
+which accounts may merge a pull request. The available rules govern what may be pushed and
+how a change must be made, and bypass permissions are the inverse of a whitelist. The
+closest available control is the CODEOWNERS requirement already in force, so "a few key
+people" is expressed as required review from named owners rather than as a merge
+restriction. Anyone claiming the stronger property is claiming something GitHub does not
+offer.
 
 `protect-integration` is new and mirrors the current `protect-main`: one approval, CODEOWNERS
 review, `test` and `build` required, stale-review dismissal, last-push approval, thread
@@ -454,27 +556,44 @@ broken on nearly every change to this suite. After implementation:
   real pull request, and the failure message names the file
 - A scratch branch touching only `docs/topics/` and targeting `main` passes
 - `gh label list` matches the taxonomy exactly, with no orphaned defaults
-- Opening each of the five forms produces the expected `type:` and `status:needs-triage`
+- Opening each of the six forms produces the expected `type:` and `status:needs-triage`
   labels and no decision label
 - The `integration` ruleset rejects a direct push
+- The `base-branch-guard` check run appears under exactly that name on a real pull request,
+  matching the string the ruleset requires
+- `protect-main` still names `refs/heads/main` after the default branch moves
 - `uv run mkdocs build --strict` still passes with the rewritten `CONTRIBUTING.md`
 
 ## Sequencing before Thursday
 
 The project lead's instruction is that everything lands before the kick-off. The ordering
-below exists because two of the six open pull requests are close to merge and the sync's
-plan was to merge #21, align #20, then review #22.
+below is not a preference. Three steps are order-dependent and one of them is a security
+regression if run out of order.
 
-Merging what is ready happens first, against `main`, before `integration` exists. Creating
-`integration` from `main` afterward means the remaining pull requests retarget onto a branch
-identical to their current base, so their diffs do not change and no contributor redoes any
-work. Retargeting before those merges would put a branch move in front of a demo.
+1. **Pin `protect-main` to `refs/heads/main`.** This happens before anything else. While its
+   condition reads `~DEFAULT_BRANCH`, moving the default would carry the protection with it
+   and leave `main` unprotected.
+2. **Merge what is ready to `main`.** The sync's plan was to merge #21, align #20, then
+   review #22. Doing this before `integration` exists means those pull requests never move.
+3. **Create `integration` from `main`.** The two branches are identical at this moment, which
+   is what makes the next step free.
+4. **Retarget the remaining pull requests.** #63, #24, #22, and #60 move to `integration` if
+   still open. #20, the FAQ, may stay on `main`. Because the branches are identical, no diff
+   changes and no contributor redoes any work.
+5. **Move the default branch to `integration`.** Last, after the protection is pinned and the
+   retargets are done.
 
-Retargeting is per pull request: #63, #24, #22, and #60 move to `integration` if still open,
-and #20, the FAQ, may stay on `main` under the documentation lane. Whether a base change
-re-triggers the required checks needs confirmation at the time rather than assumption, since
-this repository's workflows declare no `pull_request` types and a base change fires an
-`edited` event that the default type list does not include.
+Retargeting before step 2 would put a branch move in front of a demo of #60, which is the
+one avoidable way this evening damages Thursday.
+
+Whether a base change re-triggers required checks is not documented. GitHub's default
+`pull_request` activity types are `opened`, `synchronize`, and `reopened`, and the
+documentation does not say which type a base change fires or whether it fires one at all.
+This repository's workflows declare no `types`, so the safe assumption is that checks do not
+re-run. After each retarget, confirm the required checks report on the new base and close and
+reopen the pull request to force a run if they do not. Closing and reopening is the
+retrigger that costs nothing, where a rebase would cost the contributor their existing
+approvals.
 
 ## Out of scope, with reasons
 
@@ -508,3 +627,5 @@ somebody remembering this document exists.
 5. Release-branch versioning, since `sync_version.yml` moving to `integration` leaves the
    `release/*` case unspecified
 6. The DCO CI check in #52 stays indifferent to non-sign-off trailers
+7. Confirm whether Dependabot security updates honor a non-default `target-branch`, which
+   this design currently avoids needing to know

--- a/design/2026-09-09-contribution-governance-design.md
+++ b/design/2026-09-09-contribution-governance-design.md
@@ -196,6 +196,13 @@ merge forever, so it runs and passes rather than skipping. A mixed diff carrying
 documentation and specification fails, which forces the split instead of letting the
 specification ride in on a documentation change.
 
+**The promotion exemption requires the head repository to be this repository.** A pull
+request's head ref is a branch name the contributor chose, and a fork's branch may be named
+anything. Exempting on the ref alone lets somebody fork, create a branch named
+`integration`, and walk a specification change straight onto the publishing branch. The
+exemption therefore tests `head.repo.full_name` against `github.repository` first and the
+ref second. A fork cannot satisfy the first test.
+
 **The required status check context is the job name, not the workflow name.** GitHub matches
 a required check against the check run, so a ruleset requiring `base-branch-guard` while the
 workflow declares `jobs: { guard: ... }` never matches, never reports, and leaves every pull

--- a/design/2026-09-09-contribution-governance-design.md
+++ b/design/2026-09-09-contribution-governance-design.md
@@ -1,0 +1,510 @@
+# Contribution governance for the OWASP re-launch
+
+Version: 1.0
+Owner: ACS project lead
+Date: 2026-09-09
+Status: design, approved for planning
+
+The OWASP re-launch kick-off runs Thursday, September 10, 2026. The core team sync on
+September 8 named the problem plainly: many people want to contribute, and the project has
+no framework for what a valid contribution is. `CONTRIBUTING.md` exists and is too
+permissive. Issues arrive self-directed, followed immediately by a pull request nobody
+asked for. The Strategic Adoption Plan v3 puts a number on the pressure. It counted
+eighteen open issues on September 5. There are twenty-four today, four days later and
+before the kick-off has happened.
+
+This design turns the plan's committed outcome into the filter that decides what the
+project accepts, and wires that filter into branches, labels, forms, templates, and
+rulesets so it holds without a maintainer in the loop for every decision.
+
+## Goal
+
+A contributor arriving from the kick-off can answer three questions from the repository
+alone: what is the project working on right now, does my idea belong in that, and what do
+I do next. A maintainer can answer one question in seconds: does this issue enter the
+backlog. Neither answer depends on anyone remembering a rule.
+
+## What this is answering
+
+| Decision from the sync | Where it lands here |
+|---|---|
+| `CONTRIBUTING.md` is too permissive | Current Priority Scope, plus the acceptance gate |
+| `main` locked, `integration` gates all pull requests | Branching and pull request flow |
+| Contributors fork, sync, and test before submitting | Pull request gate, testing attestation |
+| Only team members assign tags, only tagged issues enter the backlog | Labels, issue intake |
+| Project needs a communicated focus so contributors self-direct | Current Priority Scope |
+| Define what code contribution is actually needed | Seeded onramp |
+| Ask the community to dogfood AGT with ACS and document failures | Conformance report form, seeded onramp |
+| Tiered contributor roles with capacity caps | Contributor sign-up form |
+| Review bottlenecks are real | Docs lane, non-blocking triage, milestones |
+
+## Current Priority Scope
+
+The project's acceptance filter is one named thing, stated once, in a section at the top of
+`CONTRIBUTING.md`. Every other surface links to it. A readable paraphrase in an issue form
+drifts from what it paraphrases and then outranks it in practice, which is why nothing else
+restates it.
+
+The name is **Current Priority Scope**. The section's job is to answer whether a piece of
+work is in or out, and *scope* draws a boundary where *focus* only describes attention. The
+failure mode from the sync was people opening self-directed issues and pull requests, which
+is a boundary problem.
+
+The section opens with the plan's commitment quoted directly, then splits the world three
+ways.
+
+**In focus** is work that feeds the runnable Guardian, the AGT interoperability benchmark,
+or the conformance evidence that makes either credible:
+
+- PR #21, the mandatory floor decision, which gates everything behind it
+- PR #22, the Claude Code, Cursor, and NVIDIA NAT adapters
+- PR #60, the AGT reference implementation under `reference-implementations/agt`
+- Ports of that reference implementation to other runtimes: Python, Go, Rust, Codex
+- Production-hardening the reference implementation, including span batching and
+  OpenTelemetry collection
+- Resolving the fail-open default, which issues #32 and #37 attack from opposite ends
+- The ACS-Core conformance claim template
+- Milestone #33, the requirement ledger and behavioral tests
+- Closing the Cursor file-read gap
+- Conformance and dogfooding reports that document where ACS fails in practice
+
+**Deferred** is work that is real, tracked, and lands after Day 90. The plan enumerates the
+v0.2.0 window, so this list is quoted rather than invented: async and composition,
+streaming, batching semantics, recursive ask, quorum, multi-tenant isolation, the Cedar
+binding, and AgBOM federation across A2A peers. Negative conformance vectors sit here too,
+tracked in #53.
+
+One distinction has to be explicit, because it will otherwise get argued in a pull request.
+*Batching semantics in the specification* is deferred to v0.2.0. *Batching in the reference
+implementation* is in focus, because Ariel named it as a foot gun in the naive
+implementation and it is exactly the production-hardening the plan wants. The two share a
+word and nothing else.
+
+**Out of scope** is what ACS deliberately leaves to deployments: the policy engine itself,
+the signature algorithm, the transport, the authentication mechanism, and the policy
+content. The specification is opinionated on the contract and permissive on the
+implementation, and that is a design position rather than a gap waiting to be filled.
+
+The section carries a review date instead of a timestamp, because a timestamp in a cached
+prefix is drift with no signal. The current window is Day 0 to Day 30, reviewed October 9,
+2026. A scheduled workflow opens an issue when that date passes. It does not fail the
+build, since a stale scope is a governance problem and blocking a documentation deploy on
+it helps nobody.
+
+## Branching and pull request flow
+
+Four kinds of branch.
+
+| Branch | Receives | Publishes |
+|---|---|---|
+| `main` | docs-lane pull requests, promotion pull requests | site, all 44 schema `$id` URIs |
+| `integration` | specification, schemas, reference implementations, adapters, tests, CI | nothing |
+| `release/vX.Y.Z` | stabilization for a tagged specification version | nothing until merged |
+| fork branches | contributor work | nothing |
+
+`main` stays the repository default. This is deliberate and runs against the sync's
+shorthand that all pull requests target `integration`, so the reasoning matters. The
+`protect-main` ruleset currently keys its condition on `~DEFAULT_BRANCH`. Moving the default
+to `integration` transfers that protection to `integration` and leaves `main` bare, which is
+a silent security regression rather than a visible one. Keeping `main` as default also gives
+the documentation lane, which will carry the most contributors and the least GitHub
+fluency, the path with no base-branch step, while a mistargeted specification pull request
+is caught by a guard at no maintainer cost.
+
+Treating the specification as code is the sync's other instruction, and it decides the
+allowlist below.
+
+### The docs lane allowlist
+
+Paths that may target `main` directly are a positive allowlist. An allowlist fails closed. A
+blocklist leaks every time somebody adds a directory.
+
+| May target `main` | Everything else targets `integration` |
+|---|---|
+| `docs/topics/**`, `docs/README.md` | `specification/**`, `docs/spec/**` |
+| `README.md`, `CONTRIBUTORS.md`, `CODE_OF_CONDUCT.md` | `docs/concepts/**`, `docs/identity/**` |
+| `CONTRIBUTING.md`, `GOVERNANCE.md`, `SECURITY.md` | `tests/`, `tools/`, `.github/` |
+| `STYLE.md`, `LICENSING.md`, `NOTICE` | `reference-implementations/`, `adapters/` |
+| `design/**` | `mkdocs.yml`, `overrides/`, `landing/`, `docs/stylesheets/`, `docs/assets/` |
+| | `pyproject.toml`, `uv.lock`, `version.txt`, `LICENSE`, `LICENSE-DOCS` |
+
+The lane is narrower than the phrase "documentation" suggests, and three groups deserve
+their reasons stated.
+
+`docs/spec/**` sits on the `integration` side because it is normative prose. The hazard the
+allowlist closes is a documentation pull request landing on `main` and publishing a
+description of a schema change still sitting on `integration`, which would put the site
+ahead of the wire contract it documents. `docs/concepts/**` and `docs/identity/**` go with
+it, since those pages define the terms the specification uses, including Intent, Capability,
+Provenance, and Trust Basis.
+
+`mkdocs.yml`, `overrides/`, `landing/`, `docs/stylesheets/`, and `docs/assets/` also sit on
+the `integration` side, even though a reader would call all five documentation. CODEOWNERS
+already treats them as privilege-escalation surfaces and says why: `mkdocs.yml` accepts a
+`hooks:` key that executes Python inside the build job, the overrides directory holds
+templates the build renders into every page, and a stylesheet or asset reaches a third party
+through `url()`, `@font-face`, or `@import` with no script at all. A lane that deploys to
+the live site on merge is the wrong lane for any of them.
+
+What remains in the documentation lane is editorial and governance prose that publishes
+without executing anything: the topics pages, the root meta files, and this design
+directory. A typo fix in a concepts page therefore takes the `integration` path and
+publishes on the next promotion. That cost is accepted, because a wide lane fails open and
+the whole point of an allowlist is that it does not.
+
+### The base-branch guard
+
+GitHub rulesets cannot express "the paths in the diff decide the base branch," so a guard
+does it. The guard splits in two so that the logic is tested and the wiring is thin.
+
+`tools/base_branch_guard.py` holds a pure function that takes a set of changed paths and
+returns the ones that require `integration`. Anything not matched by the allowlist is
+returned, which is what makes an unanticipated new directory a failure rather than a silent
+pass. The same module carries a `main()` that reads the changed files and the refs from the
+environment and exits nonzero with a message naming each offending file.
+
+`.github/workflows/pr-base-guard.yml` runs on pull requests targeting `main` and calls it.
+
+Three cases the guard has to get right. A promotion pull request from `integration` or from
+a `release/*` branch touches specification paths by definition and must pass. A guard that
+*skips* on those heads would leave a required status check permanently pending and block the
+merge forever, so it runs and passes rather than skipping. A mixed diff carrying both
+documentation and specification fails, which forces the split instead of letting the
+specification ride in on a documentation change.
+
+Two automated producers currently open pull requests against the default branch and touch
+paths outside the allowlist. Dependabot gets `target-branch: "integration"` in
+`.github/dependabot.yml`. `sync_version.yml` moves its trigger from a push to `version.txt`
+on `main` to the same push on `integration`. Neither gets an exemption in the guard, because
+an exemption keyed on an actor is a hole an actor can be impersonated through.
+
+### Promotion
+
+A promotion is a pull request from `integration` to `main`, opened by a maintainer, merged
+with a merge commit rather than a squash. Squashing a promotion flattens every specification
+commit into one and destroys the history that makes a schema change reviewable after the
+fact. `protect-main` currently allows only squash and rebase, so `merge` gets added.
+
+Promotion is when the 44 schema URIs change. That is a property worth keeping: the URIs are
+a machine-consumed contract, and batching their changes into a deliberate promotion is
+better than republishing on every specification merge.
+
+`integration` needs to stay current with `main`, since `main` receives documentation commits
+independently. `.github/workflows/sync-integration.yml` runs on every push to `main` and
+merges `main` into `integration`, so a promotion pull request stays conflict-free. It runs
+on push rather than on a schedule because the divergence starts at the merge, and a nightly
+job would leave a day of drift for a promotion to collide with.
+
+## Labels
+
+### The axes
+
+Labels become prefixed axes rather than a flat pile, and the axes split by who sets them.
+
+| Axis | Values | Applied by |
+|---|---|---|
+| `type:` | `bug`, `proposal`, `refimpl`, `conformance`, `docs` | the issue form, automatically |
+| `scope:` | `in-focus`, `deferred`, `out` | maintainers |
+| `status:` | `needs-triage`, `accepted`, `blocked`, `needs-info` | forms set `needs-triage`, maintainers set the rest |
+| `priority:` | `P0`, `P1`, `P2` | maintainers |
+| `workstream:` | `spec`, `coding-agents`, `sdk`, `identity`, `outreach` | maintainers |
+
+`priority:P0` is reserved for the four links in the plan's serial chain, so the label means
+something narrower than "important."
+
+Dates live in GitHub Milestones rather than labels. Day 14 through Day 90 become milestones
+carrying the plan's committed outcomes as their descriptions, which gives the weekly call a
+burndown instead of a status round. The plan's own risk register prescribes using that call
+for triage, and a milestone view is what makes that possible.
+
+`workstream:` uses the five names in `GOVERNANCE.md`. The plan names Reference
+Implementation, Documentation, and Testing and Validation as open lead seats, and none of
+those three is a workstream in `GOVERNANCE.md`. That mismatch is a governance question for
+the project lead and gets a tracked issue. Inventing three workstreams inside a label file
+would settle it by accident.
+
+### Who applies what
+
+The rule is that a submitter never sets a decision label. Enforcement is structural rather
+than social, in one specific place: **no issue form is permitted to stamp a `scope:`,
+`priority:`, `status:accepted`, or `workstream:` label.** That is the actual leak, because
+outside contributors already cannot apply labels at all under GitHub's permission model.
+What remains is a collaborator with triage access mislabeling, and that population is the
+maintainer roster itself.
+
+A workflow that strips decision labels applied by an account below write access was
+considered and is not in this design. It buys enforcement against people the project has
+already decided to trust, it requires a permission lookup whose behavior under
+`GITHUB_TOKEN` needs verification, and it adds a write-scoped workflow to `.github/`, which
+CODEOWNERS treats as a privilege-escalation surface. The documented rule plus forms that
+cannot stamp decisions closes the real gap. This is recorded as tracked follow-up rather
+than dropped.
+
+### Migration from the current labels
+
+The repository carries the eleven GitHub defaults plus two Dependabot labels. Renaming
+preserves assignments on existing issues, so renaming is preferred to deleting.
+
+`bug` becomes `type:bug`. `documentation` becomes `type:docs`. `enhancement` becomes
+`type:proposal`. `dependencies`, `github-actions`, `python`, and `python:uv` stay as they
+are, since Dependabot creates and expects them. `invalid`, `wontfix`, `duplicate`, and
+`question` get deleted, because GitHub's native close reasons and the Discussions routing in
+`config.yml` already cover them.
+
+Deletion removes a label from every issue carrying it, so implementation confirms each of
+those four is unused before deleting rather than assuming it from a listing.
+
+## Issue intake
+
+### Forms
+
+`blank_issues_enabled` moves to `false`. Every issue arrives through a form, which is what
+makes automatic `type:` and `status:needs-triage` labeling reliable.
+
+Five forms, each with a distinct triage path:
+
+1. **Bug report.** Something is broken: a schema error, a specification defect, the site, CI,
+   or tooling. Fields cover what is broken, where, what the specification says, and the
+   impact on implementers.
+2. **Feature or specification proposal.** A new capability. Fields cover the problem, why
+   the wire has to carry it, which of the six constituencies in `SPEC_REVIEW_PRINCIPLES.md`
+   it affects, alternatives considered, and a link to the required Discussion.
+3. **Reference implementation work.** A port, a hardening task, or a new adapter. Fields
+   cover the target runtime, what it proves, which part of the ninety-day outcome it feeds,
+   and whether the filer intends to implement it themselves.
+4. **Conformance or dogfooding report.** The community ask Ariel proposed: install ACS
+   against a real harness and document where it fails. Fields cover what was run, what was
+   expected, what happened, and the specification section involved. The form leads with the
+   redirect to private vulnerability reporting, because this is the form most likely to
+   surface a security gap.
+5. **Documentation.** The low-friction lane. Page, what is wrong or missing.
+
+Every form ends with the same required dropdown asking which part of the Current Priority
+Scope the work serves, including an honest option for "this is deferred or out of scope and
+I am filing it to be tracked." A filer who picks that option has done the triage themselves.
+
+The existing `config.yml` contact links are correct and stay. Security reporting continues
+to route to private vulnerability reporting, and questions continue to route to Discussions.
+
+### Triage
+
+Triage assigns `scope:`, then `status:`, then `priority:` and `workstream:` for anything
+accepted. Only `status:accepted` enters the backlog, which is the sync's rule stated
+mechanically.
+
+An issue that is in focus and accepted gets a milestone. An issue that is deferred gets
+`scope:deferred` and a pointer to the v0.2.0 window rather than a close, because closing
+real work tells a contributor their finding was worthless. An issue that is out of scope
+gets `scope:out` and a close with a reason.
+
+### Milestones
+
+Day 14 (September 24), Day 30 (October 9), Day 60 (November 6), and Day 90 (December 4),
+each carrying the plan's committed outcome as its description.
+
+## Pull request gate
+
+A pull request that touches specification or code references an issue carrying
+`status:accepted`. A documentation-lane pull request to `main` needs no issue. The base
+branch therefore tells a reviewer which rule applies, which is the property that makes the
+gate cheap to explain.
+
+The important question is what happens to a pull request whose issue is filed but not yet
+accepted. It is neither closed nor reviewed. Closing destroys work and reads as hostile.
+Reviewing spends the capacity the gate exists to protect. It carries `status:needs-triage`,
+a comment explains why nobody is looking at it yet, and it waits. The seeded onramp below
+means most contributors never reach that wait, because an accepted issue already exists for
+the work they came to do.
+
+`.github/workflows/pr-intake.yml` reads the pull request body, resolves referenced issues,
+and posts the explanatory comment plus `status:needs-triage` when no referenced issue
+carries `status:accepted`. It is deliberately **not** a required status check. Mistargeting
+a base branch is a mechanical error with one correct answer and belongs in a required
+check. Missing acceptance is a queue state that resolves on its own, and turning it into a
+red required check would make the gate feel like a rejection.
+
+The pull request template changes in four ways. It asks which issue the work implements and
+states the documentation-lane exemption inline. It asks the contributor to confirm they
+synced their branch and ran the guards, which is Helen's requirement from the sync and the
+one that keeps sloppy work out of review. It adds the base branch to the checklist. It keeps
+the existing specification, DCO, style, and security sections, which are already correct.
+
+## Repository governance
+
+### Rulesets
+
+`protect-main` is rewritten and hardened. Its condition moves from `~DEFAULT_BRANCH` to the
+literal `refs/heads/main`, which removes the silent-failure mode where a future default
+change unprotects it. Required approvals rise from one to two. Required status checks gain
+the base-branch guard alongside `test` and `build`. Allowed merge methods gain `merge` for
+promotions. Deletion and non-fast-forward protection stay.
+
+One honest limitation. The sync's phrasing was that nobody except a few key people can ever
+merge into `main`. GitHub rulesets do not offer a direct "only these accounts may merge a
+pull request" control, so this design approximates it with two required approvals plus the
+existing CODEOWNERS requirement. Implementation verifies whether the current ruleset schema
+exposes a stronger restriction before settling for the approximation.
+
+`protect-integration` is new and mirrors the current `protect-main`: one approval, CODEOWNERS
+review, `test` and `build` required, stale-review dismissal, last-push approval, thread
+resolution, deletion and non-fast-forward protection, squash and rebase only.
+
+`protect-release` is new and covers `refs/heads/release/*` with deletion and
+non-fast-forward protection, one approval, and the same status checks.
+
+The `restrict-transfers-deletions` repository ruleset is unaffected.
+
+### CODEOWNERS
+
+`/reference-implementations/` and `/adapters/` get owner entries once #60 and #22 land.
+Everything else in the file is already correct. The invitation caveat at the top of the file
+stays accurate and stays.
+
+## Authorship and AI assistance
+
+The current `CONTRIBUTING.md` mandates that a maintainer drops any `Co-Authored-By` trailer
+naming a model when a pull request is squashed. That mandate is removed. It is replaced by a
+named section that mandates neither direction.
+
+The human `Signed-off-by` line stays required, because the DCO is a certification about the
+origin of code and only a person can make one. Every other trailer is the contributor's
+choice. Maintainers will not add one and will not remove one, and its presence has no effect
+on review. A trailer naming a model certifies nothing and moves no responsibility.
+
+Two reasons this is the right posture for this project specifically. Some employers require
+their people to disclose AI assistance, and a visible trailer is the simplest way to satisfy
+that. More pointedly, ACS is a standard about agent provenance and traceability, and a
+project whose premise is that you should be able to see what an agent did cannot coherently
+erase the record of what an agent did to its own commits.
+
+This constrains work already planned. Issue #52 proposes enforcing the DCO in CI once the
+current pull requests land. That check verifies `Signed-off-by` and stays indifferent to
+every other trailer, so nobody implements a gate that rejects or rewrites `Co-Authored-By`.
+
+## Seeded onramp
+
+The gate and the invitation have to be the same artifact, or the gate suppresses exactly the
+contributions Track 1 needs. Ariel's invitation in the sync was open: if somebody wants to
+open a reference implementation against Codex, have at it. A gate requiring an accepted
+issue turns that invitation into a queue wait unless the accepted issue already exists.
+
+So maintainers file them before the kick-off. Each carries `scope:in-focus`,
+`status:accepted`, `help wanted`, a workstream, and a priority:
+
+1. Port the AGT reference implementation to Python
+2. Port the AGT reference implementation to Go
+3. Port the AGT reference implementation to Rust
+4. Build a reference implementation against Codex
+5. Add span batching to the reference implementation
+6. Configure OpenTelemetry collection and export in the reference implementation
+7. Dogfood AGT with ACS and file a conformance report
+8. Publish the one-page ACS-Core conformance claim template
+9. Choose and reserve a distribution name for the reference implementation
+
+Items 8 and 9 are open decisions in the plan with Day 30 dates. Filing them as issues puts
+them where the weekly call can burn them down.
+
+## Contributor sign-up form
+
+The sync's plan, taken from FinBot, is a form that collects contact details and role
+interest, with a role closed once capacity is reached. The transcript is explicit that this
+drops in the Slack channel after Thursday rather than at the kick-off, so it is specified
+here and not built as a repository change.
+
+Roles offered: reference implementation engineer, adapter engineer, specification reviewer,
+documentation, testing and validation, conformance and dogfooding, adoption and outreach.
+
+Fields collected: name, email, GitHub handle, LinkedIn, employer and whether the work
+happens on work time, role preference with a second choice, languages and runtimes, hours
+per week, timezone, prior OWASP involvement, and acknowledgement of the Code of Conduct and
+the DCO. Asking for the GitHub handle and LinkedIn up front is Helen's point about not
+chasing people afterward.
+
+The employer question is not idle curiosity. ACS is a vendor-neutral standard whose last
+single-vendor dependency is being unwound, and knowing where contributors work is what makes
+that neutrality auditable.
+
+## Testing
+
+The base-branch guard is the only new logic that can be wrong in an interesting way, so it
+gets real tests over its pure function, in `tests/test_base_branch_guard.py`, following the
+existing guard idiom.
+
+- An allowlisted documentation path against `main` passes
+- A `specification/` path against `main` fails and names the file
+- A `docs/spec/` path against `main` fails, since normative prose is not documentation
+- `mkdocs.yml` against `main` fails, since it executes Python inside the build job
+- A mixed diff of one allowlisted and one specification path fails
+- A path under a directory nobody anticipated fails, which is the fail-closed property
+- A promotion head of `integration` passes with specification paths in the diff
+- A `release/*` head passes the same way
+- Any base other than `main` passes without consulting the allowlist
+- Path matching is prefix-correct, so `docs/specimen.md` is not mistaken for `docs/spec/`
+
+The last case matters. A naive prefix check on `docs/spec` matches `docs/specimen.md` and
+routes an ordinary documentation file to `integration` for no reason.
+
+## Verification
+
+Guards prove themselves by injection rather than by reading, since `tests/conftest.py` has
+broken on nearly every change to this suite. After implementation:
+
+- `uv run pytest -v` passes locally and the new tests are collected, not skipped
+- A scratch branch touching only `specification/` and targeting `main` trips the guard in a
+  real pull request, and the failure message names the file
+- A scratch branch touching only `docs/topics/` and targeting `main` passes
+- `gh label list` matches the taxonomy exactly, with no orphaned defaults
+- Opening each of the five forms produces the expected `type:` and `status:needs-triage`
+  labels and no decision label
+- The `integration` ruleset rejects a direct push
+- `uv run mkdocs build --strict` still passes with the rewritten `CONTRIBUTING.md`
+
+## Sequencing before Thursday
+
+The project lead's instruction is that everything lands before the kick-off. The ordering
+below exists because two of the six open pull requests are close to merge and the sync's
+plan was to merge #21, align #20, then review #22.
+
+Merging what is ready happens first, against `main`, before `integration` exists. Creating
+`integration` from `main` afterward means the remaining pull requests retarget onto a branch
+identical to their current base, so their diffs do not change and no contributor redoes any
+work. Retargeting before those merges would put a branch move in front of a demo.
+
+Retargeting is per pull request: #63, #24, #22, and #60 move to `integration` if still open,
+and #20, the FAQ, may stay on `main` under the documentation lane. Whether a base change
+re-triggers the required checks needs confirmation at the time rather than assumption, since
+this repository's workflows declare no `pull_request` types and a base change fires an
+`edited` event that the default type list does not include.
+
+## Out of scope, with reasons
+
+**The org-level project board.** The sync assigned this to Scott because creating a board is
+an org-level operation. The label and milestone taxonomy here is designed to feed one, so
+the board can be built without reworking anything. It is not a repository change and cannot
+land tonight.
+
+**Declarative logic CI for specification contradictions.** Ariel's Datalog proposal is a
+real idea and a research task. Nothing about it is achievable before Thursday, and
+scaffolding it badly would be worse than leaving it open.
+
+**The label-strip enforcement workflow.** Reasoned through above. The structural fix is that
+forms cannot stamp decision labels.
+
+**Enforcing contributor role capacity.** The form closes roles at capacity through the form
+tool, not through GitHub.
+
+**The three open workstream lead seats.** A governance decision for the project lead, not a
+repository change.
+
+## Tracked follow-up
+
+Each of these gets an issue filed as part of implementation, so nothing here depends on
+somebody remembering this document exists.
+
+1. Workstream vocabulary mismatch between `GOVERNANCE.md` and the plan's open lead seats
+2. Label-strip enforcement workflow, if the permission lookup proves workable
+3. Org-level project board fed by the label and milestone taxonomy
+4. Declarative logic CI for specification contradiction detection
+5. Release-branch versioning, since `sync_version.yml` moving to `integration` leaves the
+   `release/*` case unspecified
+6. The DCO CI check in #52 stays indifferent to non-sign-off trailers

--- a/design/plans/2026-09-09-contribution-governance.md
+++ b/design/plans/2026-09-09-contribution-governance.md
@@ -1487,6 +1487,41 @@ the whole evening. Phase 2 Step 7 opens it correctly.
 
 **Not for subagent execution.** Every step below mutates the public OWASP repository in a way that is outward-facing, hard to reverse, or both: deleting a label removes it from every issue carrying it, filing issues notifies watchers, retargeting a pull request touches someone else's work, and moving the default branch changes what every visitor and every clone gets. The project lead runs these, or explicitly authorizes each one.
 
+### Run it with the executor, not by hand
+
+`tools/apply_governance.py` performs every automatable step below. It is idempotent, so a
+half-finished migration is fixed by running it again rather than by working out what
+already landed. `--dry-run` is the default and prints every command it would run.
+`--apply` is required to change anything. `--only <step>` runs one step.
+
+It is structurally incapable of merging a pull request, closing one, retargeting one, or
+deleting a label. Those are human decisions or destructive operations, and a test asserts
+no code path can emit them. Three steps therefore stay manual: merging the ready pull
+requests, retargeting the open ones, and merging the Phase 1 pull request itself.
+
+**Order for a single-maintainer migration.** The numbered steps below remain the reference.
+This is the sequence that minimizes friction when one admin runs the whole thing alone:
+
+1. `--only labels` and `--only milestones`, before anything merges, so no issue arrives
+   through a form whose labels do not exist yet
+2. Push `feature/contribution-governance`
+3. `--only branch` to create `integration` from `main`
+4. Open the Phase 1 pull request against `integration` and merge it. Do this **before**
+   creating `protect-integration`, so no approval is needed on a branch with no second
+   reviewer awake
+5. Promote `integration` to `main` with a merge commit, which publishes the site and puts
+   the guard workflow on `main`
+6. `--only rulesets` to create `protect-integration` and `protect-release`
+7. `--only default-branch`
+8. `--only required-check` to add `base-branch-guard` to `protect-main`
+9. `--only issues` to file the seeded onramp and tracked follow-up issues
+10. Retarget the open pull requests, and merge #21, #20, and #22 whenever the core team
+    decides
+
+Both new rulesets carry `protect-main`'s admin bypass. Without it a sole maintainer cannot
+merge into a branch that requires a review they are not allowed to give themselves, which
+would strand the migration with `integration` created, protected, and unmergeable.
+
 **Order is not a preference, and two orderings deadlock the repository.**
 
 Pinning `protect-main` to a literal ref precedes moving the default branch, or the

--- a/design/plans/2026-09-09-contribution-governance.md
+++ b/design/plans/2026-09-09-contribution-governance.md
@@ -1718,7 +1718,7 @@ gh api repos/GenAI-Security-Project/agent-control-standard/rulesets --jq '.[]|"\
 gh issue list --label 'help wanted' --json number,title --jq 'length'
 ```
 
-Expected: the taxonomy from Step 7, default branch `integration`, three branch rulesets plus the repository ruleset, and nine `help wanted` issues.
+Expected: the taxonomy from Step 2, default branch `integration`, three branch rulesets plus the repository ruleset, and nine `help wanted` issues.
 
 ---
 

--- a/design/plans/2026-09-09-contribution-governance.md
+++ b/design/plans/2026-09-09-contribution-governance.md
@@ -1,0 +1,1642 @@
+# Contribution Governance Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the Strategic Adoption Plan v3 committed outcome into a repository that filters contributions without a maintainer in the loop for every decision, before the OWASP kick-off on Thursday, September 10, 2026.
+
+**Architecture:** A positive path allowlist decides which changes may target the publishing branch, enforced by a pure Python function under test and a thin workflow that calls it. Issue forms stamp descriptive labels and never decision labels, so the maintainer-only rule holds structurally. `CONTRIBUTING.md` carries the single statement of Current Priority Scope that every other surface links to.
+
+**Tech Stack:** Python 3 standard library only for the guard, pytest for its tests, GitHub Actions for enforcement, GitHub issue forms (YAML), GitHub rulesets, `gh` CLI for repository configuration.
+
+**Spec:** `design/2026-09-09-contribution-governance-design.md` (v1.1)
+
+## Global Constraints
+
+- Editorial rules come from `STYLE.md`. American English, active voice, plain words. No em dashes, no semicolons, no sentences opening with a conjunction.
+- Every commit is signed off: `git commit -s`. The DCO requires it.
+- Python guards live in `tools/`, their tests in `tests/`. `testpaths = ["tests"]` in `pyproject.toml` means a test written anywhere else never runs in CI.
+- The guard uses the Python standard library only. It runs in a job that does not install `uv`, and adding a dependency to `uv.lock` for it would put the deploy gate at risk.
+- Actions are pinned to commit SHAs. Reuse the exact pins already in `.github/workflows/deploy-pages.yml`: `actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1` (v7.0.1).
+- Workflows declare `permissions: {}` at the top level and grant per job.
+- The required status check context is the **job id**. The guard job id is `base-branch-guard` and the ruleset requires that exact string. They change together or not at all.
+- Work happens on branch `feature/contribution-governance`. Phase 1 lands as a pull request. Phase 2 is operator-run.
+
+---
+
+## Phase 1: Repository files
+
+Safe for subagent execution. Every task is a file change on the feature branch, reviewable in a pull request, reversible by `git revert`.
+
+### Task 1: The base-branch guard
+
+**Files:**
+- Create: `tools/base_branch_guard.py`
+- Create: `tests/test_base_branch_guard.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `decide(paths: Iterable[str], base_ref: str, head_ref: str, head_repo: str, base_repo: str) -> tuple[int, str]` returning an exit status and a message. Also `in_docs_lane(path: str) -> bool`, `is_promotion(head_ref: str, head_repo: str, base_repo: str) -> bool`, `paths_requiring_integration(paths: Iterable[str]) -> list[str]`, and the constant `PUBLISHING_BRANCH = "main"`. Task 2 invokes the module as a script.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_base_branch_guard.py`:
+
+```python
+"""Guards for the rule that keeps specification and code off the publishing branch.
+
+The allowlist is positive, so the interesting cases are the ones nobody enumerated. A
+directory that did not exist when the list was written has to fail, and a fork branch
+named like a promotion branch has to fail, because both are how an allowlist quietly
+turns into a blocklist.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from tools.base_branch_guard import (  # noqa: E402
+    PUBLISHING_BRANCH,
+    decide,
+    in_docs_lane,
+    is_promotion,
+    paths_requiring_integration,
+)
+
+REPO = "GenAI-Security-Project/agent-control-standard"
+FORK = "someone/agent-control-standard"
+
+
+def test_allowlisted_documentation_path_is_in_the_lane():
+    assert in_docs_lane("docs/topics/core_concepts.md")
+    assert in_docs_lane("CONTRIBUTING.md")
+    assert in_docs_lane("design/2026-09-09-contribution-governance-design.md")
+
+
+def test_specification_paths_are_not_in_the_lane():
+    assert not in_docs_lane("specification/v0.1.0/acs_schema.json")
+    assert not in_docs_lane("docs/spec/instrument/hooks.md")
+
+
+def test_normative_concept_prose_is_not_in_the_lane():
+    """Concept pages define the terms the specification uses, so they travel with it."""
+    assert not in_docs_lane("docs/concepts/capability.md")
+    assert not in_docs_lane("docs/identity/standards.md")
+
+
+def test_build_surfaces_are_not_in_the_lane():
+    """A reader calls these documentation. Each one reaches code or a third party."""
+    assert not in_docs_lane("mkdocs.yml")
+    assert not in_docs_lane("overrides/main.html")
+    assert not in_docs_lane("landing/index.html")
+    assert not in_docs_lane("docs/stylesheets/extra.css")
+    assert not in_docs_lane("docs/assets/logo.svg")
+
+
+def test_directory_matching_requires_the_separator():
+    """A prefix check without the slash reads docs/specimen.md as docs/spec."""
+    assert in_docs_lane("docs/topics/anything.md")
+    assert not in_docs_lane("docs/topicsextra.md")
+
+
+def test_an_unanticipated_directory_fails_closed():
+    assert not in_docs_lane("reference-implementations/agt/main.ts")
+    assert not in_docs_lane("something/nobody/planned.txt")
+
+
+def test_paths_requiring_integration_returns_only_offenders_sorted():
+    changed = ["CONTRIBUTING.md", "specification/a.json", "docs/spec/b.md"]
+    assert paths_requiring_integration(changed) == [
+        "docs/spec/b.md",
+        "specification/a.json",
+    ]
+
+
+def test_promotion_from_integration_in_this_repository():
+    assert is_promotion("integration", REPO, REPO)
+
+
+def test_promotion_from_a_release_branch_in_this_repository():
+    assert is_promotion("release/v0.2.0", REPO, REPO)
+
+
+def test_a_fork_branch_named_integration_is_not_a_promotion():
+    """head.ref is a name the contributor chose. Only the repository check is trustworthy."""
+    assert not is_promotion("integration", FORK, REPO)
+    assert not is_promotion("release/v0.2.0", FORK, REPO)
+
+
+def test_documentation_only_pull_request_to_main_passes():
+    status, message = decide(["docs/topics/faq.md"], PUBLISHING_BRANCH, "docs/faq", FORK, REPO)
+    assert status == 0
+    assert "documentation lane" in message
+
+
+def test_specification_pull_request_to_main_fails_and_names_the_file():
+    status, message = decide(
+        ["specification/v0.1.0/acs_schema.json"], PUBLISHING_BRANCH, "spec/x", FORK, REPO
+    )
+    assert status == 1
+    assert "specification/v0.1.0/acs_schema.json" in message
+    assert "integration" in message
+
+
+def test_mixed_diff_fails():
+    status, message = decide(
+        ["CONTRIBUTING.md", "specification/a.json"], PUBLISHING_BRANCH, "mix", FORK, REPO
+    )
+    assert status == 1
+    assert "specification/a.json" in message
+    assert "CONTRIBUTING.md" not in message
+
+
+def test_promotion_passes_with_specification_paths():
+    status, message = decide(
+        ["specification/a.json"], PUBLISHING_BRANCH, "integration", REPO, REPO
+    )
+    assert status == 0
+    assert "Promotion" in message
+
+
+def test_any_other_base_passes_without_consulting_the_allowlist():
+    status, message = decide(
+        ["specification/a.json"], "integration", "spec/x", FORK, REPO
+    )
+    assert status == 0
+    assert "Nothing to check" in message
+
+
+def test_an_empty_diff_passes():
+    status, _ = decide([], PUBLISHING_BRANCH, "empty", FORK, REPO)
+    assert status == 0
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+uv run pytest tests/test_base_branch_guard.py -v
+```
+
+Expected: collection error, `ModuleNotFoundError: No module named 'tools.base_branch_guard'`.
+
+- [ ] **Step 3: Write the guard**
+
+Create `tools/base_branch_guard.py`:
+
+```python
+"""Keep specification and code changes off the publishing branch.
+
+`main` publishes the site and all 44 schema $id URIs on every merge. A change to
+normative content lands on `integration` first, so those URIs move only on a deliberate
+promotion. GitHub rulesets cannot express "the paths in the diff decide the base
+branch", so this does.
+
+The allowlist is positive. Anything it does not name requires `integration`, which makes
+a directory nobody anticipated a failure rather than a silent pass.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Iterable
+
+PUBLISHING_BRANCH = "main"
+
+# Directory prefixes that may target the publishing branch. The trailing slash is load
+# bearing: without it, a prefix test reads docs/specimen.md as a match for docs/spec.
+DOCS_LANE_DIRECTORIES = (
+    "docs/topics/",
+    "design/",
+)
+
+# Exact files that may target the publishing branch.
+#
+# mkdocs.yml, overrides/, landing/, docs/stylesheets/, and docs/assets/ are deliberately
+# absent even though a reader would call all five documentation. CODEOWNERS treats them
+# as privilege-escalation surfaces and says why: mkdocs.yml accepts a hooks: key that
+# executes Python inside the build job, overrides holds templates the build renders into
+# every page, and a stylesheet or asset reaches a third party through url(), @font-face,
+# or @import with no script at all. A lane that deploys on merge is the wrong lane for
+# any of them.
+DOCS_LANE_FILES = frozenset({
+    "docs/README.md",
+    "README.md",
+    "CONTRIBUTORS.md",
+    "CODE_OF_CONDUCT.md",
+    "CONTRIBUTING.md",
+    "GOVERNANCE.md",
+    "SECURITY.md",
+    "STYLE.md",
+    "LICENSING.md",
+    "NOTICE",
+})
+
+# Branches a promotion pull request comes from. These carry specification paths by
+# definition.
+PROMOTION_HEADS = frozenset({"integration"})
+PROMOTION_HEAD_PREFIXES = ("release/",)
+
+
+def in_docs_lane(path: str) -> bool:
+    """True when a path may target the publishing branch directly."""
+    if path in DOCS_LANE_FILES:
+        return True
+    return path.startswith(DOCS_LANE_DIRECTORIES)
+
+
+def is_promotion(head_ref: str, head_repo: str, base_repo: str) -> bool:
+    """True when this is a promotion from a branch inside this repository.
+
+    The repository test is not optional and runs first. A pull request's head ref is a
+    branch name the contributor chose, and a fork may name a branch anything, so
+    exempting on the ref alone would let somebody fork, create a branch called
+    `integration`, and walk a specification change onto the publishing branch.
+    """
+    if head_repo != base_repo:
+        return False
+    return head_ref in PROMOTION_HEADS or head_ref.startswith(PROMOTION_HEAD_PREFIXES)
+
+
+def paths_requiring_integration(paths: Iterable[str]) -> list[str]:
+    """Return every changed path that may not target the publishing branch."""
+    return sorted({path for path in paths if not in_docs_lane(path)})
+
+
+def decide(
+    paths: Iterable[str],
+    base_ref: str,
+    head_ref: str,
+    head_repo: str,
+    base_repo: str,
+) -> tuple[int, str]:
+    """Return an exit status and the message to print."""
+    if base_ref != PUBLISHING_BRANCH:
+        return 0, f"Base branch is {base_ref!r}, not {PUBLISHING_BRANCH!r}. Nothing to check."
+    if is_promotion(head_ref, head_repo, base_repo):
+        return 0, f"Promotion from {head_ref!r}. Specification paths are expected here."
+    offenders = paths_requiring_integration(paths)
+    if not offenders:
+        return 0, "Every changed path is in the documentation lane."
+    listing = "\n".join(f"  {path}" for path in offenders)
+    return 1, (
+        f"These paths may not target `{PUBLISHING_BRANCH}`. Retarget this pull request "
+        f"at `integration`:\n{listing}\n\n"
+        f"`{PUBLISHING_BRANCH}` publishes the site and all 44 schema $id URIs on merge, "
+        "so specification and code changes land on `integration` and publish on a "
+        "promotion. See CONTRIBUTING.md."
+    )
+
+
+def main(argv: list[str]) -> int:
+    """Read the changed paths from a file and the refs from the environment."""
+    if len(argv) != 2:
+        print("usage: base_branch_guard.py <file-listing-changed-paths>", file=sys.stderr)
+        return 2
+    with open(argv[1], encoding="utf-8") as handle:
+        paths = [line.strip() for line in handle if line.strip()]
+    status, message = decide(
+        paths,
+        os.environ.get("BASE_REF", ""),
+        os.environ.get("HEAD_REF", ""),
+        os.environ.get("HEAD_REPO", ""),
+        os.environ.get("BASE_REPO", ""),
+    )
+    print(message, file=sys.stderr if status else sys.stdout)
+    return status
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+uv run pytest tests/test_base_branch_guard.py -v
+```
+
+Expected: 15 passed.
+
+- [ ] **Step 5: Run the whole suite to confirm nothing else broke**
+
+```bash
+uv run pytest -v
+```
+
+Expected: all pass. `tests/conftest.py` has broken on nearly every change to this suite, so this step is not optional.
+
+- [ ] **Step 6: Prove the guard by injection, not by reading**
+
+```bash
+printf 'specification/v0.1.0/acs_schema.json\nCONTRIBUTING.md\n' > /tmp/changed.txt
+BASE_REF=main HEAD_REF=spec/x HEAD_REPO=fork/x BASE_REPO=GenAI-Security-Project/agent-control-standard \
+  python3 tools/base_branch_guard.py /tmp/changed.txt; echo "exit=$?"
+```
+
+Expected: exit=1, message naming `specification/v0.1.0/acs_schema.json` and not `CONTRIBUTING.md`.
+
+```bash
+printf 'docs/topics/faq.md\n' > /tmp/changed.txt
+BASE_REF=main HEAD_REF=docs/x HEAD_REPO=fork/x BASE_REPO=GenAI-Security-Project/agent-control-standard \
+  python3 tools/base_branch_guard.py /tmp/changed.txt; echo "exit=$?"
+```
+
+Expected: exit=0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tools/base_branch_guard.py tests/test_base_branch_guard.py
+git commit -s -m "Add the guard that keeps specification changes off the publishing branch"
+```
+
+---
+
+### Task 2: The guard workflow
+
+**Files:**
+- Create: `.github/workflows/pr-base-guard.yml`
+
+**Interfaces:**
+- Consumes: `tools/base_branch_guard.py` from Task 1, invoked as a script with one argument.
+- Produces: a check run named `base-branch-guard`. Phase 2 Task 10 requires that exact string in `protect-main`.
+
+- [ ] **Step 1: Write the workflow**
+
+```yaml
+# Keeps specification and code changes off the branch that publishes on merge.
+#
+# The job id below is the check run name the protect-main ruleset requires. Renaming the
+# job without renaming the required check leaves a required status check that never
+# reports, which blocks every pull request to main permanently.
+name: PR base guard
+
+on:
+  pull_request:
+    branches: ["main"]
+
+permissions: {}
+
+concurrency:
+  group: pr-base-guard-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  base-branch-guard:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Both endpoints of the diff have to be present to compute a merge base.
+          fetch-depth: 0
+
+      - name: List the changed paths
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          # Three-dot compares against the merge base, so commits that landed on the
+          # base branch after this pull request opened do not count as its changes.
+          git diff --name-only "${BASE_SHA}...${HEAD_SHA}" > changed.txt
+          cat changed.txt
+
+      - name: Enforce the documentation lane
+        env:
+          # Passed through the environment rather than interpolated into the shell. A
+          # head ref is contributor-controlled text and ${{ }} inside run: executes.
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+        run: python3 tools/base_branch_guard.py changed.txt
+```
+
+- [ ] **Step 2: Validate the YAML parses**
+
+```bash
+python3 -c "import sys,yaml;yaml.safe_load(open('.github/workflows/pr-base-guard.yml'))" \
+  && echo OK
+```
+
+Expected: `OK`. If `yaml` is unavailable, use `uv run python -c ...`.
+
+- [ ] **Step 3: Confirm the job id matches the required check string**
+
+```bash
+grep -n "^  base-branch-guard:" .github/workflows/pr-base-guard.yml
+```
+
+Expected: one match. This string is repeated in Phase 2 Task 10.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/pr-base-guard.yml
+git commit -s -m "Run the base branch guard on every pull request to main"
+```
+
+---
+
+### Task 3: Issue forms
+
+**Files:**
+- Create: `.github/ISSUE_TEMPLATE/1-bug.yml`
+- Create: `.github/ISSUE_TEMPLATE/2-proposal.yml`
+- Create: `.github/ISSUE_TEMPLATE/3-reference-implementation.yml`
+- Create: `.github/ISSUE_TEMPLATE/4-conformance-report.yml`
+- Create: `.github/ISSUE_TEMPLATE/5-documentation.yml`
+- Create: `.github/ISSUE_TEMPLATE/6-something-else.yml`
+- Modify: `.github/ISSUE_TEMPLATE/config.yml`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: labels `type:bug`, `type:proposal`, `type:refimpl`, `type:conformance`, `type:docs`, and `status:needs-triage`. Phase 2 Task 8 creates them. A form referencing a label that does not exist fails to apply it silently.
+
+**Rule for every form:** no form may declare a `scope:`, `priority:`, `workstream:`, or `status:accepted` label. That prohibition is the whole enforcement mechanism for maintainer-only decision labels.
+
+- [ ] **Step 1: Write the scope dropdown that every form shares**
+
+Each of the six forms ends with this block, copied verbatim:
+
+```yaml
+  - type: dropdown
+    id: priority-scope
+    attributes:
+      label: Current Priority Scope
+      description: >-
+        Read the Current Priority Scope in CONTRIBUTING.md before answering. An honest
+        "deferred" is more useful to us than a hopeful "in focus".
+      options:
+        - Feeds the runnable Guardian reference implementation
+        - Feeds the AGT interoperability benchmark
+        - Feeds conformance evidence
+        - This is deferred or out of scope and I am filing it to be tracked
+        - I am not sure
+    validations:
+      required: true
+```
+
+- [ ] **Step 2: Write `1-bug.yml`**
+
+```yaml
+name: Bug report
+description: Something is broken in the specification, a schema, the site, CI, or tooling.
+title: "[Bug] "
+labels: ["type:bug", "status:needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        Do not file a security vulnerability here. Use private vulnerability reporting.
+        See SECURITY.md.
+  - type: textarea
+    id: what
+    attributes:
+      label: What is broken
+      description: One or two sentences.
+    validations:
+      required: true
+  - type: input
+    id: where
+    attributes:
+      label: Where
+      description: File path, schema $id, documentation page, or workflow name.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What the specification says, and what happens instead
+      description: Quote the line if there is one.
+    validations:
+      required: true
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact on implementers
+      description: Who breaks, and how badly.
+    validations:
+      required: false
+  - type: dropdown
+    id: priority-scope
+    attributes:
+      label: Current Priority Scope
+      description: >-
+        Read the Current Priority Scope in CONTRIBUTING.md before answering. An honest
+        "deferred" is more useful to us than a hopeful "in focus".
+      options:
+        - Feeds the runnable Guardian reference implementation
+        - Feeds the AGT interoperability benchmark
+        - Feeds conformance evidence
+        - This is deferred or out of scope and I am filing it to be tracked
+        - I am not sure
+    validations:
+      required: true
+```
+
+- [ ] **Step 3: Write `2-proposal.yml`**
+
+```yaml
+name: Feature or specification proposal
+description: A new capability, hook, event, or AgBOM component.
+title: "[Proposal] "
+labels: ["type:proposal", "status:needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        Specification changes affect every downstream implementer. Open a Discussion
+        first and link it below.
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: What cannot be done today. Describe the problem, not the solution.
+    validations:
+      required: true
+  - type: textarea
+    id: wire
+    attributes:
+      label: Why the wire has to carry it
+      description: >-
+        SPEC_REVIEW_PRINCIPLES.md principle 3 is that something goes on the wire only if
+        it is lost otherwise. Make that case.
+    validations:
+      required: true
+  - type: checkboxes
+    id: constituencies
+    attributes:
+      label: Which constituencies this affects
+      description: From SPEC_REVIEW_PRINCIPLES.md principle 2.
+      options:
+        - label: Observed Agent implementers
+        - label: Guardian implementers
+        - label: Policy authors
+        - label: Auditors and incident responders
+        - label: Platform and harness vendors
+        - label: Enterprise deployers
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Including riding an existing element rather than adding one.
+    validations:
+      required: true
+  - type: input
+    id: discussion
+    attributes:
+      label: Discussion link
+      description: The Discussion thread where this was raised.
+    validations:
+      required: true
+  - type: dropdown
+    id: priority-scope
+    attributes:
+      label: Current Priority Scope
+      description: >-
+        Read the Current Priority Scope in CONTRIBUTING.md before answering. An honest
+        "deferred" is more useful to us than a hopeful "in focus".
+      options:
+        - Feeds the runnable Guardian reference implementation
+        - Feeds the AGT interoperability benchmark
+        - Feeds conformance evidence
+        - This is deferred or out of scope and I am filing it to be tracked
+        - I am not sure
+    validations:
+      required: true
+```
+
+- [ ] **Step 4: Write `3-reference-implementation.yml`**
+
+```yaml
+name: Reference implementation work
+description: A port to another runtime, a hardening task, or a new adapter.
+title: "[RefImpl] "
+labels: ["type:refimpl", "status:needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        This is the work the project needs most. Check the open issues labelled
+        `help wanted` before filing, since the one you want may already be accepted.
+  - type: input
+    id: target
+    attributes:
+      label: Target runtime or language
+      description: For example Python, Go, Rust, Codex, or an existing implementation to harden.
+    validations:
+      required: true
+  - type: textarea
+    id: proves
+    attributes:
+      label: What this proves
+      description: >-
+        A reference implementation earns its place by demonstrating something the
+        specification alone cannot. Say what.
+    validations:
+      required: true
+  - type: dropdown
+    id: intent
+    attributes:
+      label: Do you intend to implement this yourself
+      options:
+        - "Yes, I want this assigned to me"
+        - "No, I am proposing it for someone else"
+    validations:
+      required: true
+  - type: dropdown
+    id: priority-scope
+    attributes:
+      label: Current Priority Scope
+      description: >-
+        Read the Current Priority Scope in CONTRIBUTING.md before answering. An honest
+        "deferred" is more useful to us than a hopeful "in focus".
+      options:
+        - Feeds the runnable Guardian reference implementation
+        - Feeds the AGT interoperability benchmark
+        - Feeds conformance evidence
+        - This is deferred or out of scope and I am filing it to be tracked
+        - I am not sure
+    validations:
+      required: true
+```
+
+- [ ] **Step 5: Write `4-conformance-report.yml`**
+
+```yaml
+name: Conformance or dogfooding report
+description: You ran ACS against a real harness and it did not behave as specified.
+title: "[Conformance] "
+labels: ["type:conformance", "status:needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        **Stop if you found a security vulnerability.** A dogfooding run is the most
+        likely place to find one. Do not describe it here. Use private vulnerability
+        reporting: see SECURITY.md.
+  - type: textarea
+    id: setup
+    attributes:
+      label: What you ran
+      description: Harness, adapter, Guardian, versions, and configuration.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+      description: Cite the specification section that led you to expect it.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: What happened
+      description: Include the wire payload if you have it, with secrets removed.
+    validations:
+      required: true
+  - type: dropdown
+    id: priority-scope
+    attributes:
+      label: Current Priority Scope
+      description: >-
+        Read the Current Priority Scope in CONTRIBUTING.md before answering. An honest
+        "deferred" is more useful to us than a hopeful "in focus".
+      options:
+        - Feeds the runnable Guardian reference implementation
+        - Feeds the AGT interoperability benchmark
+        - Feeds conformance evidence
+        - This is deferred or out of scope and I am filing it to be tracked
+        - I am not sure
+    validations:
+      required: true
+```
+
+- [ ] **Step 6: Write `5-documentation.yml`**
+
+```yaml
+name: Documentation
+description: A page is wrong, unclear, or missing.
+title: "[Docs] "
+labels: ["type:docs", "status:needs-triage"]
+body:
+  - type: input
+    id: page
+    attributes:
+      label: Page
+      description: URL or file path.
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What is wrong or missing
+    validations:
+      required: true
+  - type: dropdown
+    id: priority-scope
+    attributes:
+      label: Current Priority Scope
+      description: >-
+        Read the Current Priority Scope in CONTRIBUTING.md before answering. An honest
+        "deferred" is more useful to us than a hopeful "in focus".
+      options:
+        - Feeds the runnable Guardian reference implementation
+        - Feeds the AGT interoperability benchmark
+        - Feeds conformance evidence
+        - This is deferred or out of scope and I am filing it to be tracked
+        - I am not sure
+    validations:
+      required: true
+```
+
+- [ ] **Step 7: Write `6-something-else.yml`**
+
+This form is the most important one in the set and the easiest to leave out. The strongest technical contribution the project has received from outside fits none of the five above.
+
+```yaml
+name: Something else
+description: >-
+  A structural finding, a question the other forms do not fit, or an idea that does not
+  have a shape yet. Nothing here is required except the description.
+title: ""
+labels: ["type:proposal", "status:needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        The other forms exist to make triage fast. This one exists because the most
+        valuable contributions rarely fit a form. Tell us what you found.
+  - type: textarea
+    id: what
+    attributes:
+      label: What you want to tell us
+    validations:
+      required: true
+```
+
+- [ ] **Step 8: Turn off blank issues**
+
+Modify `.github/ISSUE_TEMPLATE/config.yml`. Change `blank_issues_enabled: true` to `false` and add a line of comment above it. Leave the three `contact_links` exactly as they are.
+
+```yaml
+# Routes people away from filing security reports as public issues, which is
+# the single most common way a coordinated disclosure gets blown.
+#
+# Blank issues are off because a form is what applies the type: and
+# status:needs-triage labels that triage depends on. The "Something else" form is the
+# open door that keeps this from turning away a finding that fits no template.
+
+blank_issues_enabled: false
+```
+
+- [ ] **Step 9: Verify no form declares a decision label**
+
+```bash
+grep -rn "labels:" .github/ISSUE_TEMPLATE/ | grep -E "scope:|priority:|workstream:|status:accepted" \
+  && echo "FAIL: a form stamps a decision label" || echo "OK"
+```
+
+Expected: `OK`.
+
+- [ ] **Step 10: Verify all six forms parse**
+
+```bash
+for f in .github/ISSUE_TEMPLATE/*.yml; do
+  python3 -c "import sys,yaml;yaml.safe_load(open('$f'))" || echo "FAIL $f"
+done; echo done
+```
+
+Expected: no `FAIL` lines.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add .github/ISSUE_TEMPLATE/
+git commit -s -m "Route every issue through a form that cannot stamp a decision label"
+```
+
+---
+
+### Task 4: Pull request template
+
+**Files:**
+- Modify: `.github/pull_request_template.md`
+
+**Interfaces:**
+- Consumes: the acceptance gate defined in Task 5's `CONTRIBUTING.md`.
+- Produces: nothing other tasks read.
+
+- [ ] **Step 1: Replace the file**
+
+```markdown
+## What changed
+
+<!-- One or two sentences. What does this PR do and why? -->
+
+## Which issue does this implement
+
+Closes #
+
+<!-- A change that alters behavior, normative text, or adds code needs an issue carrying
+     `status:accepted`. If yours is not accepted yet, open the PR anyway. It will wait
+     rather than be closed. See Current Priority Scope in CONTRIBUTING.md. -->
+
+- [ ] This is an editorial correction (typo, grammar, link, formatting) with no change in
+      meaning, so it needs no issue
+
+## Base branch
+
+- [ ] `integration`, because this touches the specification, schemas, a reference
+      implementation, an adapter, tests, or CI
+- [ ] `main`, because every changed path is on the documentation lane allowlist in
+      CONTRIBUTING.md
+
+## Type of change
+
+- [ ] Specification change (schema, hooks, events, AgBOM)
+- [ ] Reference implementation or adapter
+- [ ] Documentation
+- [ ] Tooling or CI
+- [ ] Governance (licensing, security policy, contributor docs)
+
+## Specification changes
+
+<!-- Delete this section if you touched nothing under specification/ or docs/spec/. -->
+
+- [ ] I opened a [Discussion](https://github.com/GenAI-Security-Project/agent-control-standard/discussions) before this PR
+- [ ] Schema changes validate against the JSON Schema spec
+- [ ] I described the impact on downstream implementers below
+
+**Breaking for implementers?** <!-- yes or no, and what breaks -->
+
+## I tested this
+
+- [ ] I synced my branch with the base branch before opening this
+- [ ] `uv run pytest -v` passes on my machine
+- [ ] `uv run mkdocs build --strict` passes on my machine
+
+<!-- These three are the difference between a review and a debugging session. A PR that
+     has not been run is not ready for someone else's afternoon. -->
+
+## Checklist
+
+- [ ] Commits are signed off with `git commit -s` (required by the DCO)
+- [ ] Prose follows [STYLE.md](../STYLE.md)
+- [ ] No secrets, tokens, or internal URLs in the diff
+
+## Security
+
+- [ ] This change has no security impact
+
+<!-- If it does, describe it. Do not open a PR for an unreported vulnerability.
+     Report it privately first: see SECURITY.md. -->
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/pull_request_template.md
+git commit -s -m "Ask a pull request which issue it implements and whether it was run"
+```
+
+---
+
+### Task 5: CONTRIBUTING.md
+
+**Files:**
+- Modify: `CONTRIBUTING.md`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: the single statement of Current Priority Scope. Forms, templates, and `GOVERNANCE.md` link here and never restate it.
+
+- [ ] **Step 1: Insert the Current Priority Scope section**
+
+Place it immediately after the opening paragraph and before `## Code of Conduct`.
+
+```markdown
+## Current Priority Scope
+
+Reviewed at each milestone. Current window: Day 0 to Day 30. Next review October 9, 2026.
+
+The project has one committed outcome:
+
+> A runnable Guardian Agent reference implementation, benchmarked for interoperability
+> against Microsoft Agent Governance Toolkit, in the hands of external evaluators within
+> ninety days of the September 10, 2026 kick-off. Everything else either feeds that
+> outcome or gets deferred.
+
+Every issue and every pull request is accepted against that sentence. This section is the
+only place that scope is stated, so if something here disagrees with a form, a template,
+or a comment, this wins.
+
+**In focus.** Work that feeds the runnable Guardian, the interoperability benchmark, or
+the conformance evidence that makes either credible:
+
+- The mandatory floor decision in PR #21, which gates everything behind it
+- The Claude Code, Cursor, and NVIDIA NAT adapters in PR #22
+- The AGT reference implementation in PR #60
+- Ports of that reference implementation to other runtimes: Python, Go, Rust, Codex
+- Production-hardening it, including span batching and OpenTelemetry collection
+- Resolving the fail-open default, which issues #32 and #37 attack from opposite ends
+- The ACS-Core conformance claim template
+- The requirement ledger and behavioral tests in milestone #33
+- Closing the Cursor file-read gap
+- Conformance and dogfooding reports that document where ACS fails in practice
+
+**Deferred to v0.2.0.** Real work, tracked, landing after Day 90: async and composition,
+streaming, batching semantics, recursive ask, quorum, multi-tenant isolation, the Cedar
+binding, and AgBOM federation across A2A peers. Negative conformance vectors sit here
+too, in #53.
+
+One distinction, because it will otherwise get argued in a pull request. *Batching
+semantics in the specification* is deferred. *Batching in the reference implementation*
+is in focus, because it is exactly the production-hardening the project asked for. The
+two share a word and nothing else.
+
+**Out of scope.** What ACS leaves to deployments by design: the policy engine, the
+signature algorithm, the transport, the authentication mechanism, and the policy content.
+The specification is opinionated on the contract and permissive on the implementation.
+That is a position, not a gap waiting to be filled.
+
+A proposal that is deferred or out of scope is still worth filing. It gets a label and a
+tracking issue rather than a close, because a finding the project cannot act on this
+quarter is not a finding without value.
+
+## How work gets accepted
+
+Anyone may open an issue. Only an issue carrying `status:accepted` enters the backlog,
+and only a maintainer applies that label.
+
+A pull request that changes behavior, alters normative text, or adds code references an
+accepted issue. An editorial correction does not, wherever it lands: a typo, a grammar
+fix, a broken link, or a formatting repair that leaves the meaning untouched needs no
+issue.
+
+If you open a pull request against an issue that is not accepted yet, it will not be
+closed and it will not be reviewed. It waits, and a comment will say so. Start from an
+issue labelled `help wanted` if you want work that is already accepted.
+
+Maintainers apply `scope:`, `priority:`, `workstream:`, and `status:accepted`. No issue
+form can apply them, which is what makes the rule hold rather than depend on everyone
+remembering it.
+```
+
+- [ ] **Step 2: Replace the Development Process section**
+
+Replace steps 1 through 6 and the paragraph that follows.
+
+```markdown
+## Development Process
+
+1. **Fork the repository** and clone your fork
+2. **Branch from `integration`.** Use `spec/`, `refimpl/`, `fix/`, or `docs/` followed by
+   a short description
+3. **Make your changes** following the style guide
+4. **Sync with `integration` and run the guards** before you open anything. `uv run
+   pytest -v` and `uv run mkdocs build --strict` both have to pass on your machine
+5. **Sign your commits** with `git commit -s` (required by the DCO below)
+6. **Open a pull request against `integration`**
+7. **Address review feedback** to land your change
+
+`integration` is the default branch, so a pull request opened from the GitHub interface
+already targets it. `main` publishes the site and all 44 schema `$id` URIs on merge, so
+it takes only two kinds of change: a promotion from `integration`, and an editorial
+change to a path on the allowlist below. A guard enforces this and will tell you to
+retarget if you get it wrong.
+
+Paths that may target `main` directly: `docs/topics/`, `design/`, `docs/README.md`,
+`README.md`, `CONTRIBUTORS.md`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `GOVERNANCE.md`,
+`SECURITY.md`, `STYLE.md`, `LICENSING.md`, and `NOTICE`. Everything else goes to
+`integration`, including `docs/spec/`, `docs/concepts/`, `docs/identity/`, `mkdocs.yml`,
+`overrides/`, `landing/`, `docs/stylesheets/`, and `docs/assets/`.
+
+For changes to the spec itself (`acs_schema.json`, hooks, events), open a
+[Discussion](https://github.com/GenAI-Security-Project/agent-control-standard/discussions)
+before submitting a PR. These affect downstream implementers and warrant a longer
+conversation.
+```
+
+- [ ] **Step 3: Replace the authorship paragraph**
+
+Delete the paragraph beginning "Commits land under human authorship" and ending "carry through unchanged." Insert this section in its place.
+
+```markdown
+## Authorship and AI assistance
+
+Commits land under human authorship. The DCO below is a certification about the origin of
+code, and only a person can make one, so every commit carries a `Signed-off-by` line
+naming a human who takes responsibility for what the commit contains. That requirement
+does not move.
+
+The rest of the trailers are your call. Many contributors here write with AI assistance.
+If you want to record that with a `Co-Authored-By` trailer naming the tool, keep it. If
+you would rather not, leave it off. Maintainers will not add one and will not remove one,
+and its presence has no effect on how a change is reviewed.
+
+A trailer naming a model certifies nothing and moves no responsibility. The human on the
+`Signed-off-by` line answers for the change either way. Some employers require their
+people to disclose AI assistance, and a visible trailer is the simplest way to satisfy
+that. ACS is also a standard about agent provenance, and a project built on the premise
+that you should be able to see what an agent did has no business erasing the record of
+what an agent did to its own commits.
+```
+
+- [ ] **Step 4: Replace the What We Need section**
+
+```markdown
+## What We Need
+
+Start with [issues labelled `help wanted`](https://github.com/GenAI-Security-Project/agent-control-standard/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22).
+Every one of them is already accepted, which means you can open a pull request against it
+without waiting on triage.
+
+The highest-value contribution right now is running ACS against a real harness and
+documenting where it fails. Install the reference implementation, wire it to a coding
+agent, and file a conformance report when the behavior and the specification disagree.
+That is worth more to this project than a patch nobody asked for.
+```
+
+- [ ] **Step 5: Verify the build still passes**
+
+```bash
+uv run mkdocs build --strict && uv run pytest -v
+```
+
+Expected: both pass.
+
+- [ ] **Step 6: Check for style violations**
+
+```bash
+grep -nE '(^|\. )(And|But|So|Or|Yet) |—|; ' CONTRIBUTING.md || echo "clean"
+```
+
+Expected: `clean`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add CONTRIBUTING.md
+git commit -s -m "State the Current Priority Scope and the acceptance gate in CONTRIBUTING"
+```
+
+---
+
+### Task 6: GOVERNANCE.md triage authority
+
+**Files:**
+- Modify: `GOVERNANCE.md`
+
+**Interfaces:**
+- Consumes: the label taxonomy from Task 3 and Phase 2 Task 8.
+- Produces: nothing other tasks read.
+
+- [ ] **Step 1: Insert a section after "Workstream leads"**
+
+```markdown
+## Triage authority
+
+Workstream leads and the project lead apply the decision labels: `scope:`, `priority:`,
+`workstream:`, and `status:accepted`. Nobody else does, and no issue form can.
+
+Minimum triage on a new issue is two labels, `scope:` and `status:`. `priority:` and
+`workstream:` are enrichment applied to accepted work. Requiring four decisions per issue
+is how a taxonomy stops getting used in month two.
+
+`priority:P0` is reserved for work on the serial chain the Strategic Adoption Plan names:
+the mandatory floor decision, the adapters, the installable Guardian, and the
+interoperability benchmark. It does not mean important.
+
+Triage runs on the weekly call. Promotion from `integration` to `main` is a standing item
+on the same call, and the project lead owns merging it.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add GOVERNANCE.md
+git commit -s -m "Record who applies decision labels and what minimum triage is"
+```
+
+---
+
+### Task 7: Automation workflows
+
+**Files:**
+- Create: `.github/workflows/sync-integration.yml`
+- Create: `.github/workflows/open-promotion.yml`
+- Create: `.github/workflows/pr-intake.yml`
+- Modify: `.github/dependabot.yml`
+- Modify: `.github/workflows/sync_version.yml:8` (the `branches` key)
+
+**Interfaces:**
+- Consumes: the labels `status:accepted` and `status:needs-triage` from Phase 2 Task 8.
+- Produces: nothing other tasks read.
+
+- [ ] **Step 1: Write `sync-integration.yml`**
+
+It opens a pull request rather than pushing. `protect-integration` requires pull requests and blocks non-fast-forward updates, and `GITHUB_TOKEN` is not a bypass actor, so a workflow that pushed would fail on every run.
+
+```yaml
+# Keeps integration current with main, so a promotion pull request stays conflict-free.
+#
+# This opens a pull request rather than pushing. The protect-integration ruleset requires
+# pull requests and blocks non-fast-forward updates, and GITHUB_TOKEN is not a bypass
+# actor, so a push here would fail on every run.
+name: Sync integration from main
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: sync-integration
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Open or update the sync pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if git merge-base --is-ancestor origin/main origin/integration; then
+            echo "integration already contains main. Nothing to sync."
+            exit 0
+          fi
+          if gh pr list --base integration --head main --state open --json number \
+             --jq 'length' | grep -qv '^0$'; then
+            echo "A sync pull request is already open."
+            exit 0
+          fi
+          gh pr create --base integration --head main \
+            --title "Sync integration from main" \
+            --body "Documentation landed on main. This carries it to integration so the next promotion does not conflict. The content already passed review on main."
+```
+
+- [ ] **Step 2: Write `open-promotion.yml`**
+
+Promotion is the operation the branching model exists to serve, and it is the one nobody remembers to do. A machine opening the pull request means the decision on the weekly call is whether to merge rather than whether to remember.
+
+```yaml
+# Opens the weekly promotion pull request from integration to main.
+#
+# A three-tier branching model pays its whole cost up front and returns nothing until a
+# promotion happens. Leaving promotion to memory is how integration accrues specification
+# work while main keeps publishing schemas nobody is reading.
+name: Open promotion pull request
+
+on:
+  schedule:
+    # 13:00 UTC Thursday, the morning of the weekly call.
+    - cron: "0 13 * * 4"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Open the promotion pull request if integration is ahead
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          AHEAD="$(git rev-list --count origin/main..origin/integration)"
+          if [ "$AHEAD" -eq 0 ]; then
+            echo "integration is not ahead of main. Nothing to promote."
+            exit 0
+          fi
+          if gh pr list --base main --head integration --state open --json number \
+             --jq 'length' | grep -qv '^0$'; then
+            echo "A promotion pull request is already open."
+            exit 0
+          fi
+          gh pr create --base main --head integration \
+            --title "Promote integration to main" \
+            --body "${AHEAD} commit(s) ahead. Merging publishes the site and every schema \$id URI. Merge with a merge commit, not a squash: squashing flattens the specification history that makes a schema change reviewable later."
+```
+
+- [ ] **Step 3: Write `pr-intake.yml`**
+
+The trigger is `pull_request_target` because `GITHUB_TOKEN` is read-only on a `pull_request` event from a fork, which is every external contribution. That trigger is a privilege-escalation surface, so this workflow checks out no code and runs nothing the contributor supplied.
+
+```yaml
+# Tells a contributor why their pull request is waiting, and labels it so the queue is
+# visible.
+#
+# pull_request_target is used deliberately: GITHUB_TOKEN is read-only on a pull_request
+# event from a fork, and every external contribution is a fork. That trigger runs with
+# repository write scope against the base branch, so this workflow checks out no code,
+# runs no contributor-supplied script, and reads the pull request body from the event
+# payload as data.
+name: PR intake
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened]
+
+permissions: {}
+
+concurrency:
+  group: pr-intake-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: read
+    steps:
+      - name: Check whether a referenced issue is accepted
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+          # Issue numbers are extracted from the body text, which is untrusted input. It
+          # is matched against a digit pattern and never evaluated.
+          NUMBERS="$(printf '%s' "${PR_BODY:-}" | grep -oE '#[0-9]+' | tr -d '#' | sort -u || true)"
+          if printf '%s' "${PR_BODY:-}" | grep -qiE '^\s*-\s*\[x\]\s*This is an editorial correction'; then
+            echo "Declared editorial. No issue required."
+            exit 0
+          fi
+          for n in $NUMBERS; do
+            if gh issue view "$n" --repo "$REPO" --json labels \
+               --jq '.labels[].name' 2>/dev/null | grep -qx 'status:accepted'; then
+              echo "Issue #$n is accepted."
+              exit 0
+            fi
+          done
+          gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label 'status:needs-triage'
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "Thanks for this. It is queued rather than ignored.
+
+This pull request does not reference an issue carrying \`status:accepted\`, so a maintainer has not looked at it yet and will not until the underlying issue is triaged. Nothing here is rejected. See [Current Priority Scope](https://github.com/GenAI-Security-Project/agent-control-standard/blob/main/CONTRIBUTING.md#current-priority-scope) for what the project is working on, and [\`help wanted\`](https://github.com/GenAI-Security-Project/agent-control-standard/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) for work that is already accepted.
+
+If this is an editorial correction, tick that box in the description and this comment stops applying."
+```
+
+- [ ] **Step 4: Remove the Dependabot problem rather than solving it**
+
+Modify `.github/dependabot.yml`. Add no `target-branch` key. Instead add this comment above `updates:` so the next reader knows why:
+
+```yaml
+# No target-branch key. Dependabot follows the default branch, which is `integration`,
+# so both routine and security updates land there and never meet the base-branch guard.
+# Setting target-branch would make this depend on undocumented security-update targeting
+# behavior for no benefit.
+```
+
+- [ ] **Step 5: Point version sync at integration**
+
+In `.github/workflows/sync_version.yml`, change `branches: ["main"]` to `branches: ["integration"]`. `version.txt`, `pyproject.toml`, and `uv.lock` are all off the documentation lane, so a version-sync pull request against `main` would trip the guard.
+
+- [ ] **Step 6: Validate every workflow parses**
+
+```bash
+for f in .github/workflows/*.yml .github/dependabot.yml; do
+  python3 -c "import sys,yaml;yaml.safe_load(open('$f'))" || echo "FAIL $f"
+done; echo done
+```
+
+Expected: no `FAIL` lines.
+
+- [ ] **Step 7: Confirm no workflow grants more than it needs**
+
+```bash
+grep -n -A4 "^permissions:" .github/workflows/*.yml
+```
+
+Expected: every file has a top-level `permissions: {}` and per-job grants no wider than those written above.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add .github/workflows/ .github/dependabot.yml
+git commit -s -m "Automate the sync, the promotion, and the intake comment"
+```
+
+---
+
+### Task 8: Scope staleness reminder
+
+**Files:**
+- Create: `.github/workflows/scope-review.yml`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing.
+
+- [ ] **Step 1: Write the workflow**
+
+```yaml
+# Opens an issue when the Current Priority Scope review date passes.
+#
+# It opens an issue rather than failing a build. A stale scope is a governance problem,
+# and blocking a documentation deploy on one helps nobody.
+name: Scope review reminder
+
+on:
+  schedule:
+    - cron: "0 14 * * 1"
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  remind:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Open a review issue if the date has passed
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          # The date is read from CONTRIBUTING.md so the document stays the single source.
+          DUE="$(grep -oE 'Next review [A-Z][a-z]+ [0-9]{1,2}, [0-9]{4}' CONTRIBUTING.md \
+                 | head -1 | sed 's/^Next review //')"
+          if [ -z "$DUE" ]; then
+            echo "::error file=CONTRIBUTING.md::No 'Next review <date>' line found"
+            exit 1
+          fi
+          DUE_EPOCH="$(date -u -d "$DUE" +%s)"
+          NOW_EPOCH="$(date -u +%s)"
+          if [ "$NOW_EPOCH" -lt "$DUE_EPOCH" ]; then
+            echo "Scope review not due until $DUE."
+            exit 0
+          fi
+          TITLE="Review the Current Priority Scope (was due $DUE)"
+          if gh issue list --state open --search "$TITLE in:title" --json number \
+             --jq 'length' | grep -qv '^0$'; then
+            echo "Reminder already open."
+            exit 0
+          fi
+          gh issue create --title "$TITLE" \
+            --label 'status:needs-triage' \
+            --body "The Current Priority Scope in CONTRIBUTING.md passed its review date of $DUE. Confirm what is still in focus, move what has shipped, and set the next review date. This is a standing item for the weekly call."
+```
+
+- [ ] **Step 2: Verify the date parser finds the line Task 5 wrote**
+
+```bash
+grep -oE 'Next review [A-Z][a-z]+ [0-9]{1,2}, [0-9]{4}' CONTRIBUTING.md
+```
+
+Expected: `Next review October 9, 2026`. If this prints nothing, Task 5 Step 1 was not applied verbatim and the workflow will fail on its first run.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/scope-review.yml
+git commit -s -m "Open an issue when the priority scope review date passes"
+```
+
+---
+
+### Task 9: Open the Phase 1 pull request
+
+- [ ] **Step 1: Run everything one last time**
+
+```bash
+uv run pytest -v && uv run mkdocs build --strict
+```
+
+Expected: both pass.
+
+- [ ] **Step 2: Push and open the pull request against `main`**
+
+At this point `integration` does not exist yet, and the diff touches `.github/`, `tools/`, and `tests/`, all off the documentation lane. This pull request therefore predates the rule it installs, which is the one time that is acceptable. Phase 2 Step 3 creates `integration` from `main` after it merges.
+
+```bash
+git push -u origin feature/contribution-governance
+gh pr create --base main --title "Install the contribution governance for the OWASP re-launch" \
+  --body-file design/2026-09-09-contribution-governance-design.md
+```
+
+---
+
+## Phase 2: Live repository configuration
+
+**Not for subagent execution.** Every step below mutates the public OWASP repository in a way that is outward-facing, hard to reverse, or both: deleting a label removes it from every issue carrying it, filing issues notifies watchers, retargeting a pull request touches someone else's work, and moving the default branch changes what every visitor and every clone gets. The project lead runs these, or explicitly authorizes each one.
+
+**Order is not a preference.** Step 1 is a security precondition for Step 5.
+
+- [ ] **Step 1: Pin `protect-main` to the literal ref**
+
+This happens before anything else. While the condition reads `~DEFAULT_BRANCH`, moving the default carries the protection with it and leaves `main` unprotected.
+
+```bash
+gh api repos/GenAI-Security-Project/agent-control-standard/rulesets/20720988 > /tmp/protect-main.json
+# Edit /tmp/protect-main.json:
+#   conditions.ref_name.include: ["refs/heads/main"]
+#   rules[pull_request].parameters.allowed_merge_methods: ["squash","rebase","merge"]
+#   rules[required_status_checks].parameters.required_status_checks:
+#     add {"context":"base-branch-guard"} alongside test and build
+# Leave required_approving_review_count at 1. Raising it throttles promotion, which is
+# the operation this whole model exists to serve.
+gh api -X PUT repos/GenAI-Security-Project/agent-control-standard/rulesets/20720988 \
+  --input /tmp/protect-main.json
+gh api repos/GenAI-Security-Project/agent-control-standard/rulesets/20720988 \
+  --jq '.conditions.ref_name.include, [.rules[]|select(.type=="required_status_checks").parameters.required_status_checks[].context]'
+```
+
+Expected: `["refs/heads/main"]` and a list containing `test`, `build`, `base-branch-guard`.
+
+- [ ] **Step 2: Merge the ready pull requests to `main`**
+
+Core-team decision, not an automated step. The sync's plan was merge #21, align #20 with it, then review #22. Doing this before `integration` exists means those pull requests never move.
+
+- [ ] **Step 3: Merge the Phase 1 pull request, then create `integration`**
+
+```bash
+gh pr merge <phase-1-pr> --squash
+git fetch origin main
+git push origin origin/main:refs/heads/integration
+gh api repos/GenAI-Security-Project/agent-control-standard/branches --jq '.[].name'
+```
+
+Expected: `integration` present and identical to `main`.
+
+- [ ] **Step 4: Retarget the remaining open pull requests**
+
+Because the branches are identical, no diff changes and no contributor redoes work.
+
+```bash
+for n in 63 24 22 60; do
+  gh pr edit "$n" --base integration || echo "skip $n"
+done
+gh pr list --json number,baseRefName --jq '.[] | "#\(.number) -> \(.baseRefName)"'
+```
+
+`#20`, the FAQ, may stay on `main`.
+
+After each retarget, confirm the required checks reported on the new base. Whether a base change re-triggers them is undocumented, and this repository's workflows declare no `pull_request` types. If a check is missing, close and reopen the pull request to force a run. Do not ask the contributor to rebase, which would cost them their existing approvals.
+
+- [ ] **Step 5: Create `protect-integration` and `protect-release`**
+
+```bash
+gh api -X POST repos/GenAI-Security-Project/agent-control-standard/rulesets \
+  --input /tmp/protect-integration.json
+```
+
+`protect-integration` mirrors the pre-change `protect-main`: target `refs/heads/integration`, one approval, `require_code_owner_review: true`, `dismiss_stale_reviews_on_push: true`, `require_last_push_approval: true`, `required_review_thread_resolution: true`, required checks `test` and `build`, merge methods squash and rebase, plus deletion and non-fast-forward rules.
+
+`protect-release` targets `refs/heads/release/*` with deletion, non-fast-forward, one approval, and the same required checks.
+
+- [ ] **Step 6: Move the default branch to `integration`**
+
+Last. Step 1 must already be done.
+
+```bash
+gh repo edit GenAI-Security-Project/agent-control-standard --default-branch integration
+gh api repos/GenAI-Security-Project/agent-control-standard --jq '.default_branch'
+gh api repos/GenAI-Security-Project/agent-control-standard/rulesets/20720988 \
+  --jq '.conditions.ref_name.include'
+```
+
+Expected: `integration`, and `protect-main` still naming `refs/heads/main`.
+
+- [ ] **Step 7: Create the label taxonomy**
+
+```bash
+gh label edit bug           --name 'type:bug'        --color 'd73a4a'
+gh label edit documentation --name 'type:docs'       --color '0075ca'
+gh label edit enhancement   --name 'type:proposal'   --color 'a2eeef'
+gh label create 'type:refimpl'     --color '1d76db' --description 'Reference implementation or adapter work'
+gh label create 'type:conformance' --color '5319e7' --description 'Conformance or dogfooding report'
+
+gh label create 'scope:in-focus' --color '0e8a16' --description 'Feeds the ninety-day committed outcome. Maintainers only'
+gh label create 'scope:deferred' --color 'fbca04' --description 'Real work, tracked, lands after Day 90. Maintainers only'
+gh label create 'scope:out'      --color 'e4e669' --description 'Outside what ACS does by design. Maintainers only'
+
+gh label create 'status:needs-triage' --color 'ededed' --description 'Not yet triaged. Applied by the issue forms'
+gh label create 'status:accepted'     --color '0e8a16' --description 'In the backlog. Maintainers only'
+gh label create 'status:blocked'      --color 'b60205' --description 'Waiting on another decision or PR'
+gh label create 'status:needs-info'   --color 'd876e3' --description 'Waiting on the filer'
+
+gh label create 'priority:P0' --color 'b60205' --description 'On the serial chain to the benchmark. Maintainers only'
+gh label create 'priority:P1' --color 'd93f0b' --description 'Maintainers only'
+gh label create 'priority:P2' --color 'fef2c0' --description 'Maintainers only'
+
+for w in spec coding-agents sdk identity outreach; do
+  gh label create "workstream:$w" --color 'c5def5' --description 'Owning workstream. Maintainers only'
+done
+```
+
+Before deleting, confirm each is unused. Deletion removes a label from every issue carrying it.
+
+```bash
+for l in invalid wontfix duplicate question; do
+  echo -n "$l: "; gh issue list --label "$l" --state all --json number --jq 'length'
+done
+```
+
+Delete only those reporting `0`.
+
+- [ ] **Step 8: Create the milestones**
+
+```bash
+for m in "Day 14:2026-09-24:Reference Implementation lead named. PR #21 floor decision closed. Discussions seeded. Domain transfer counterpart identified." \
+         "Day 30:2026-10-09:PR #22 merged with the emission-conformance suite in CI. Documentation and Testing lead seats filled. Conformance claim template published. Fail-open resolution decided." \
+         "Day 60:2026-11-06:Installable reference Guardian published. Milestone #33 requirement ledger drafted. AARM mapping session held. Domains transferred. OpenSSF registered." \
+         "Day 90:2026-12-04:AGT interoperability benchmark published with results and disagreements. Cursor file-read gap closed. One external ACS-Core compatibility claim."; do
+  IFS=':' read -r title due desc <<< "$m"
+  gh api -X POST repos/GenAI-Security-Project/agent-control-standard/milestones \
+    -f title="$title" -f due_on="${due}T23:59:59Z" -f description="$desc"
+done
+```
+
+- [ ] **Step 9: File the seeded onramp issues**
+
+Each carries `scope:in-focus`, `status:accepted`, `help wanted`, a workstream, and a priority. These are what make the acceptance gate an invitation rather than a queue.
+
+1. Port the AGT reference implementation to Python
+2. Port the AGT reference implementation to Go
+3. Port the AGT reference implementation to Rust
+4. Build a reference implementation against Codex
+5. Add span batching to the reference implementation
+6. Configure OpenTelemetry collection and export in the reference implementation
+7. Dogfood AGT with ACS and file a conformance report
+8. Publish the one-page ACS-Core conformance claim template
+9. Choose and reserve a distribution name for the reference implementation
+
+Items 8 and 9 are open decisions in the plan with Day 30 dates, so give them the Day 30 milestone.
+
+- [ ] **Step 10: File the tracked follow-up issues**
+
+1. Workstream vocabulary mismatch between `GOVERNANCE.md` and the plan's open lead seats
+2. Label-strip enforcement workflow, if the permission lookup proves workable
+3. Org-level project board fed by this label and milestone taxonomy (needs org admin)
+4. Declarative logic CI for specification contradiction detection
+5. Release-branch versioning, unspecified now that `sync_version.yml` follows `integration`
+6. A comment on #52 that the DCO check stays indifferent to non-sign-off trailers
+7. Confirm whether Dependabot security updates honor a non-default `target-branch`
+
+- [ ] **Step 11: Verify the whole thing end to end**
+
+```bash
+# The guard fires on a real pull request
+git checkout -b scratch/guard-proof integration
+echo "# proof" >> specification/README.md 2>/dev/null || true
+git commit -asm "Prove the guard fires" && git push -u origin scratch/guard-proof
+gh pr create --base main --title "Scratch: prove the guard" --body "Delete me"
+```
+
+Expected: the `base-branch-guard` check fails and names `specification/README.md`. Close the pull request and delete the branch afterward.
+
+```bash
+gh label list --limit 100
+gh api repos/GenAI-Security-Project/agent-control-standard --jq '.default_branch'
+gh api repos/GenAI-Security-Project/agent-control-standard/rulesets --jq '.[]|"\(.name) \(.target) \(.enforcement)"'
+gh issue list --label 'help wanted' --json number,title --jq 'length'
+```
+
+Expected: the taxonomy from Step 7, default branch `integration`, three branch rulesets plus the repository ruleset, and nine `help wanted` issues.
+
+---
+
+## Self-review
+
+**Spec coverage.** Current Priority Scope is Task 5. Branching and the allowlist are Tasks 1, 2, and 5 plus Phase 2 Steps 3, 5, and 6. Labels are Task 3 and Phase 2 Step 7. Issue intake is Task 3. The pull request gate is Tasks 4 and 7. Rulesets are Phase 2 Steps 1 and 5. CODEOWNERS for `reference-implementations/` and `adapters/` is deliberately deferred until #60 and #22 land, since a CODEOWNERS entry for a path that does not exist is inert. Authorship is Task 5. The seeded onramp is Phase 2 Step 9. The sign-up form is specified in the design and is not a repository change. Promotion cadence is Task 7 and Task 6.
+
+**Placeholders.** None. Every code and configuration step carries its content. Phase 2 Steps 1 and 5 describe ruleset JSON edits rather than pasting the full payload, because the payload is fetched from the live API and edited in place, and a stale copy pasted here would overwrite fields the API added since.
+
+**Type consistency.** `decide`, `in_docs_lane`, `is_promotion`, and `paths_requiring_integration` carry the same signatures in the test file, the implementation, and the Interfaces block. `is_promotion` takes three arguments everywhere. The job id `base-branch-guard` is identical in Task 2 Step 1, Task 2 Step 3, Phase 2 Step 1, and Phase 2 Step 11. The label strings in Task 3 match those created in Phase 2 Step 7.

--- a/design/plans/2026-09-09-contribution-governance.md
+++ b/design/plans/2026-09-09-contribution-governance.md
@@ -53,9 +53,10 @@ turns into a blocklist.
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+# Matches the import style the other tools tests use, in test_publish_schemas.py:12.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
 
-from tools.base_branch_guard import (  # noqa: E402
+from base_branch_guard import (  # noqa: E402
     PUBLISHING_BRANCH,
     decide,
     in_docs_lane,
@@ -142,12 +143,19 @@ def test_specification_pull_request_to_main_fails_and_names_the_file():
 
 
 def test_mixed_diff_fails():
+    """Only the offenders appear in the listing.
+
+    The assertion reads the listing rather than the whole message on purpose. The
+    message ends with "See CONTRIBUTING.md.", so a naive `not in message` check can
+    never pass and would push somebody into changing the guard to satisfy the test.
+    """
     status, message = decide(
         ["CONTRIBUTING.md", "specification/a.json"], PUBLISHING_BRANCH, "mix", FORK, REPO
     )
+    listing = message.split("\n\n")[0]
     assert status == 1
-    assert "specification/a.json" in message
-    assert "CONTRIBUTING.md" not in message
+    assert "specification/a.json" in listing
+    assert "CONTRIBUTING.md" not in listing
 
 
 def test_promotion_passes_with_specification_paths():
@@ -316,7 +324,7 @@ if __name__ == "__main__":
 uv run pytest tests/test_base_branch_guard.py -v
 ```
 
-Expected: 15 passed.
+Expected: 16 passed.
 
 - [ ] **Step 5: Run the whole suite to confirm nothing else broke**
 
@@ -419,11 +427,11 @@ jobs:
 - [ ] **Step 2: Validate the YAML parses**
 
 ```bash
-python3 -c "import sys,yaml;yaml.safe_load(open('.github/workflows/pr-base-guard.yml'))" \
+uv run python -c "import yaml;yaml.safe_load(open('.github/workflows/pr-base-guard.yml'))" \
   && echo OK
 ```
 
-Expected: `OK`. If `yaml` is unavailable, use `uv run python -c ...`.
+Expected: `OK`. It must be `uv run python`: the system `python3` on this machine has no PyYAML, and `import yaml` there fails with `ModuleNotFoundError` that reads like broken YAML.
 
 - [ ] **Step 3: Confirm the job id matches the required check string**
 
@@ -809,7 +817,7 @@ Expected: `OK`.
 
 ```bash
 for f in .github/ISSUE_TEMPLATE/*.yml; do
-  python3 -c "import sys,yaml;yaml.safe_load(open('$f'))" || echo "FAIL $f"
+  uv run python -c "import yaml;yaml.safe_load(open('$f'))" || echo "FAIL $f"
 done; echo done
 ```
 
@@ -1072,13 +1080,26 @@ uv run mkdocs build --strict && uv run pytest -v
 
 Expected: both pass.
 
-- [ ] **Step 6: Check for style violations**
+- [ ] **Step 6: Check for style violations in the prose you wrote**
+
+**Do not edit the DCO.** `CONTRIBUTING.md` lines 79 and 85 carry the Developer's
+Certificate of Origin, which is verbatim legal text ending each clause with `; or`. Those
+two semicolons are correct and must not be "fixed". The check below excludes that block
+so nobody reaches for it.
 
 ```bash
-grep -nE '(^|\. )(And|But|So|Or|Yet) |—|; ' CONTRIBUTING.md || echo "clean"
+awk '/^## Developer.s Certificate of Origin/{skip=1;next} skip && /^## /{skip=0} !skip' \
+  CONTRIBUTING.md > /tmp/prose.txt
+grep -nE '(^|\. )(And|But|So|Or|Yet) |—|; ' /tmp/prose.txt || echo "clean"
 ```
 
-Expected: `clean`.
+Expected: `clean`. Verified against the file as it stands today: 89 of 114 lines kept,
+every section except the DCO block, no matches.
+
+The `skip && /^## /` condition is what keeps the sections *after* the DCO in the check. A
+plain range expression drops everything to the end of the file, and `awk '!/pattern/,0'`
+does not exclude anything at all, because the range opens on the first line that does not
+match, which is line one.
 
 - [ ] **Step 7: Commit**
 
@@ -1184,8 +1205,7 @@ jobs:
             echo "integration already contains main. Nothing to sync."
             exit 0
           fi
-          if gh pr list --base integration --head main --state open --json number \
-             --jq 'length' | grep -qv '^0$'; then
+          if [ "$(gh pr list --base integration --head main --state open --json number --jq 'length')" -gt 0 ]; then
             echo "A sync pull request is already open."
             exit 0
           fi
@@ -1236,8 +1256,7 @@ jobs:
             echo "integration is not ahead of main. Nothing to promote."
             exit 0
           fi
-          if gh pr list --base main --head integration --state open --json number \
-             --jq 'length' | grep -qv '^0$'; then
+          if [ "$(gh pr list --base main --head integration --state open --json number --jq 'length')" -gt 0 ]; then
             echo "A promotion pull request is already open."
             exit 0
           fi
@@ -1293,6 +1312,14 @@ jobs:
             echo "Declared editorial. No issue required."
             exit 0
           fi
+          # The `edited` trigger fires every time anyone touches the body, so without
+          # this the queue comment gets reposted on every edit.
+          if gh pr view "$PR_NUMBER" --repo "$REPO" --json comments \
+             --jq '[.comments[] | select(.author.login == "github-actions")] | length' \
+             | grep -qv '^0$'; then
+            echo "Already commented on this pull request."
+            exit 0
+          fi
           for n in $NUMBERS; do
             if gh issue view "$n" --repo "$REPO" --json labels \
                --jq '.labels[].name' 2>/dev/null | grep -qx 'status:accepted'; then
@@ -1327,7 +1354,7 @@ In `.github/workflows/sync_version.yml`, change `branches: ["main"]` to `branche
 
 ```bash
 for f in .github/workflows/*.yml .github/dependabot.yml; do
-  python3 -c "import sys,yaml;yaml.safe_load(open('$f'))" || echo "FAIL $f"
+  uv run python -c "import yaml;yaml.safe_load(open('$f'))" || echo "FAIL $f"
 done; echo done
 ```
 
@@ -1336,7 +1363,7 @@ Expected: no `FAIL` lines.
 - [ ] **Step 7: Confirm no workflow grants more than it needs**
 
 ```bash
-grep -n -A4 "^permissions:" .github/workflows/*.yml
+grep -n -A4 "^permissions:" .github/workflows/*.yml .github/workflows/*.yaml
 ```
 
 Expected: every file has a top-level `permissions: {}` and per-job grants no wider than those written above.
@@ -1404,8 +1431,7 @@ jobs:
             exit 0
           fi
           TITLE="Review the Current Priority Scope (was due $DUE)"
-          if gh issue list --state open --search "$TITLE in:title" --json number \
-             --jq 'length' | grep -qv '^0$'; then
+          if [ "$(gh issue list --state open --search "$TITLE in:title" --json number --jq 'length')" -gt 0 ]; then
             echo "Reminder already open."
             exit 0
           fi
@@ -1441,15 +1467,19 @@ uv run pytest -v && uv run mkdocs build --strict
 
 Expected: both pass.
 
-- [ ] **Step 2: Push and open the pull request against `main`**
+- [ ] **Step 2: Push the branch, and stop**
 
-At this point `integration` does not exist yet, and the diff touches `.github/`, `tools/`, and `tests/`, all off the documentation lane. This pull request therefore predates the rule it installs, which is the one time that is acceptable. Phase 2 Step 3 creates `integration` from `main` after it merges.
+Push only. Do not open the pull request yet.
 
 ```bash
 git push -u origin feature/contribution-governance
-gh pr create --base main --title "Install the contribution governance for the OWASP re-launch" \
-  --body-file design/2026-09-09-contribution-governance-design.md
 ```
+
+This diff touches `.github/`, `tools/`, and `tests/`, every one of them off the
+documentation lane. A pull request from here to `main` would fail the guard it is
+installing, so it goes to `integration` instead, and `integration` does not exist until
+Phase 2 Step 3. Opening it against `main` now is the single mistake that would deadlock
+the whole evening. Phase 2 Step 6 opens it correctly.
 
 ---
 
@@ -1457,37 +1487,41 @@ gh pr create --base main --title "Install the contribution governance for the OW
 
 **Not for subagent execution.** Every step below mutates the public OWASP repository in a way that is outward-facing, hard to reverse, or both: deleting a label removes it from every issue carrying it, filing issues notifies watchers, retargeting a pull request touches someone else's work, and moving the default branch changes what every visitor and every clone gets. The project lead runs these, or explicitly authorizes each one.
 
-**Order is not a preference.** Step 1 is a security precondition for Step 5.
+**Order is not a preference, and two orderings deadlock the repository.**
 
-- [ ] **Step 1: Pin `protect-main` to the literal ref**
+Pinning `protect-main` to a literal ref precedes moving the default branch, or the
+protection follows the default and leaves `main` bare. Separately, `base-branch-guard`
+becomes a required status check **last**, after the guard workflow has reached `main`
+through a promotion. A required check that no workflow reports never turns green, so
+adding it early blocks the Phase 1 pull request that installs the guard, and then blocks
+every documentation pull request whose merge commit does not yet carry the workflow.
+Version 1.0 of this plan added it in Step 1 and deadlocked itself.
 
-This happens before anything else. While the condition reads `~DEFAULT_BRANCH`, moving the default carries the protection with it and leaves `main` unprotected.
+- [ ] **Step 1: Pin `protect-main` to the literal ref, without the new check**
 
 ```bash
 gh api repos/GenAI-Security-Project/agent-control-standard/rulesets/20720988 > /tmp/protect-main.json
 # Edit /tmp/protect-main.json:
 #   conditions.ref_name.include: ["refs/heads/main"]
 #   rules[pull_request].parameters.allowed_merge_methods: ["squash","rebase","merge"]
-#   rules[required_status_checks].parameters.required_status_checks:
-#     add {"context":"base-branch-guard"} alongside test and build
+# Do NOT add base-branch-guard yet. That is Step 9.
 # Leave required_approving_review_count at 1. Raising it throttles promotion, which is
 # the operation this whole model exists to serve.
 gh api -X PUT repos/GenAI-Security-Project/agent-control-standard/rulesets/20720988 \
   --input /tmp/protect-main.json
 gh api repos/GenAI-Security-Project/agent-control-standard/rulesets/20720988 \
-  --jq '.conditions.ref_name.include, [.rules[]|select(.type=="required_status_checks").parameters.required_status_checks[].context]'
+  --jq '.conditions.ref_name.include, [.rules[]|select(.type=="pull_request").parameters.allowed_merge_methods]'
 ```
 
-Expected: `["refs/heads/main"]` and a list containing `test`, `build`, `base-branch-guard`.
+Expected: `["refs/heads/main"]` and `["squash","rebase","merge"]`.
 
 - [ ] **Step 2: Merge the ready pull requests to `main`**
 
 Core-team decision, not an automated step. The sync's plan was merge #21, align #20 with it, then review #22. Doing this before `integration` exists means those pull requests never move.
 
-- [ ] **Step 3: Merge the Phase 1 pull request, then create `integration`**
+- [ ] **Step 3: Create `integration` from `main`**
 
 ```bash
-gh pr merge <phase-1-pr> --squash
 git fetch origin main
 git push origin origin/main:refs/heads/integration
 gh api repos/GenAI-Security-Project/agent-control-standard/branches --jq '.[].name'
@@ -1495,9 +1529,20 @@ gh api repos/GenAI-Security-Project/agent-control-standard/branches --jq '.[].na
 
 Expected: `integration` present and identical to `main`.
 
-- [ ] **Step 4: Retarget the remaining open pull requests**
+- [ ] **Step 4: Create `protect-integration` and `protect-release`**
 
-Because the branches are identical, no diff changes and no contributor redoes work.
+```bash
+gh api -X POST repos/GenAI-Security-Project/agent-control-standard/rulesets \
+  --input /tmp/protect-integration.json
+```
+
+`protect-integration` mirrors the pre-change `protect-main`: target `refs/heads/integration`, one approval, `require_code_owner_review: true`, `dismiss_stale_reviews_on_push: true`, `require_last_push_approval: true`, `required_review_thread_resolution: true`, required checks `test` and `build`, merge methods squash and rebase, plus deletion and non-fast-forward rules.
+
+`protect-release` targets `refs/heads/release/*` with deletion, non-fast-forward, one approval, and the same required checks.
+
+- [ ] **Step 5: Retarget the remaining open pull requests**
+
+Because `integration` and `main` are identical, no diff changes and no contributor redoes work.
 
 ```bash
 for n in 63 24 22 60; do
@@ -1510,20 +1555,36 @@ gh pr list --json number,baseRefName --jq '.[] | "#\(.number) -> \(.baseRefName)
 
 After each retarget, confirm the required checks reported on the new base. Whether a base change re-triggers them is undocumented, and this repository's workflows declare no `pull_request` types. If a check is missing, close and reopen the pull request to force a run. Do not ask the contributor to rebase, which would cost them their existing approvals.
 
-- [ ] **Step 5: Create `protect-integration` and `protect-release`**
+- [ ] **Step 6: Open the Phase 1 pull request against `integration` and merge it**
 
 ```bash
-gh api -X POST repos/GenAI-Security-Project/agent-control-standard/rulesets \
-  --input /tmp/protect-integration.json
+gh pr create --base integration --head feature/contribution-governance \
+  --title "Install the contribution governance for the OWASP re-launch" \
+  --body "Implements design/2026-09-09-contribution-governance-design.md v1.1."
 ```
 
-`protect-integration` mirrors the pre-change `protect-main`: target `refs/heads/integration`, one approval, `require_code_owner_review: true`, `dismiss_stale_reviews_on_push: true`, `require_last_push_approval: true`, `required_review_thread_resolution: true`, required checks `test` and `build`, merge methods squash and rebase, plus deletion and non-fast-forward rules.
+It targets `integration` because the diff touches `.github/`, `tools/`, and `tests/`. Merge it once `test` and `build` pass.
 
-`protect-release` targets `refs/heads/release/*` with deletion, non-fast-forward, one approval, and the same required checks.
+- [ ] **Step 7: Promote to `main`**
 
-- [ ] **Step 6: Move the default branch to `integration`**
+This publishes the site with the new `CONTRIBUTING.md` and, just as importantly, puts the guard workflow on `main` so Step 9 has something that can report.
 
-Last. Step 1 must already be done.
+```bash
+gh pr create --base main --head integration --title "Promote integration to main" \
+  --body "Carries the contribution governance to the publishing branch."
+```
+
+Merge with a **merge commit**, not a squash.
+
+```bash
+git fetch origin main && git ls-tree --name-only origin/main .github/workflows/
+```
+
+Expected: `pr-base-guard.yml` present on `main`.
+
+- [ ] **Step 8: Move the default branch to `integration`**
+
+Step 1 must already be done.
 
 ```bash
 gh repo edit GenAI-Security-Project/agent-control-standard --default-branch integration
@@ -1534,30 +1595,46 @@ gh api repos/GenAI-Security-Project/agent-control-standard/rulesets/20720988 \
 
 Expected: `integration`, and `protect-main` still naming `refs/heads/main`.
 
-- [ ] **Step 7: Create the label taxonomy**
+- [ ] **Step 9: Add `base-branch-guard` to the required checks on `main`**
+
+Only now. The workflow reached `main` in Step 7, so the check can report.
+
+```bash
+gh api repos/GenAI-Security-Project/agent-control-standard/rulesets/20720988 > /tmp/protect-main.json
+# Add {"context":"base-branch-guard"} to
+# rules[required_status_checks].parameters.required_status_checks
+gh api -X PUT repos/GenAI-Security-Project/agent-control-standard/rulesets/20720988 \
+  --input /tmp/protect-main.json
+gh api repos/GenAI-Security-Project/agent-control-standard/rulesets/20720988 \
+  --jq '[.rules[]|select(.type=="required_status_checks").parameters.required_status_checks[].context]'
+```
+
+Expected: `["test","build","base-branch-guard"]`.
+
+- [ ] **Step 10: Create the label taxonomy**
 
 ```bash
 gh label edit bug           --name 'type:bug'        --color 'd73a4a'
 gh label edit documentation --name 'type:docs'       --color '0075ca'
 gh label edit enhancement   --name 'type:proposal'   --color 'a2eeef'
-gh label create 'type:refimpl'     --color '1d76db' --description 'Reference implementation or adapter work'
-gh label create 'type:conformance' --color '5319e7' --description 'Conformance or dogfooding report'
+gh label create --force 'type:refimpl'     --color '1d76db' --description 'Reference implementation or adapter work'
+gh label create --force 'type:conformance' --color '5319e7' --description 'Conformance or dogfooding report'
 
-gh label create 'scope:in-focus' --color '0e8a16' --description 'Feeds the ninety-day committed outcome. Maintainers only'
-gh label create 'scope:deferred' --color 'fbca04' --description 'Real work, tracked, lands after Day 90. Maintainers only'
-gh label create 'scope:out'      --color 'e4e669' --description 'Outside what ACS does by design. Maintainers only'
+gh label create --force 'scope:in-focus' --color '0e8a16' --description 'Feeds the ninety-day committed outcome. Maintainers only'
+gh label create --force 'scope:deferred' --color 'fbca04' --description 'Real work, tracked, lands after Day 90. Maintainers only'
+gh label create --force 'scope:out'      --color 'e4e669' --description 'Outside what ACS does by design. Maintainers only'
 
-gh label create 'status:needs-triage' --color 'ededed' --description 'Not yet triaged. Applied by the issue forms'
-gh label create 'status:accepted'     --color '0e8a16' --description 'In the backlog. Maintainers only'
-gh label create 'status:blocked'      --color 'b60205' --description 'Waiting on another decision or PR'
-gh label create 'status:needs-info'   --color 'd876e3' --description 'Waiting on the filer'
+gh label create --force 'status:needs-triage' --color 'ededed' --description 'Not yet triaged. Applied by the issue forms'
+gh label create --force 'status:accepted'     --color '0e8a16' --description 'In the backlog. Maintainers only'
+gh label create --force 'status:blocked'      --color 'b60205' --description 'Waiting on another decision or PR'
+gh label create --force 'status:needs-info'   --color 'd876e3' --description 'Waiting on the filer'
 
-gh label create 'priority:P0' --color 'b60205' --description 'On the serial chain to the benchmark. Maintainers only'
-gh label create 'priority:P1' --color 'd93f0b' --description 'Maintainers only'
-gh label create 'priority:P2' --color 'fef2c0' --description 'Maintainers only'
+gh label create --force 'priority:P0' --color 'b60205' --description 'On the serial chain to the benchmark. Maintainers only'
+gh label create --force 'priority:P1' --color 'd93f0b' --description 'Maintainers only'
+gh label create --force 'priority:P2' --color 'fef2c0' --description 'Maintainers only'
 
 for w in spec coding-agents sdk identity outreach; do
-  gh label create "workstream:$w" --color 'c5def5' --description 'Owning workstream. Maintainers only'
+  gh label create --force "workstream:$w" --color 'c5def5' --description 'Owning workstream. Maintainers only'
 done
 ```
 
@@ -1571,7 +1648,7 @@ done
 
 Delete only those reporting `0`.
 
-- [ ] **Step 8: Create the milestones**
+- [ ] **Step 11: Create the milestones**
 
 ```bash
 for m in "Day 14:2026-09-24:Reference Implementation lead named. PR #21 floor decision closed. Discussions seeded. Domain transfer counterpart identified." \
@@ -1584,7 +1661,7 @@ for m in "Day 14:2026-09-24:Reference Implementation lead named. PR #21 floor de
 done
 ```
 
-- [ ] **Step 9: File the seeded onramp issues**
+- [ ] **Step 12: File the seeded onramp issues**
 
 Each carries `scope:in-focus`, `status:accepted`, `help wanted`, a workstream, and a priority. These are what make the acceptance gate an invitation rather than a queue.
 
@@ -1600,7 +1677,7 @@ Each carries `scope:in-focus`, `status:accepted`, `help wanted`, a workstream, a
 
 Items 8 and 9 are open decisions in the plan with Day 30 dates, so give them the Day 30 milestone.
 
-- [ ] **Step 10: File the tracked follow-up issues**
+- [ ] **Step 13: File the tracked follow-up issues**
 
 1. Workstream vocabulary mismatch between `GOVERNANCE.md` and the plan's open lead seats
 2. Label-strip enforcement workflow, if the permission lookup proves workable
@@ -1610,17 +1687,29 @@ Items 8 and 9 are open decisions in the plan with Day 30 dates, so give them the
 6. A comment on #52 that the DCO check stays indifferent to non-sign-off trailers
 7. Confirm whether Dependabot security updates honor a non-default `target-branch`
 
-- [ ] **Step 11: Verify the whole thing end to end**
+- [ ] **Step 14: Verify the whole thing end to end**
 
 ```bash
-# The guard fires on a real pull request
-git checkout -b scratch/guard-proof integration
-echo "# proof" >> specification/README.md 2>/dev/null || true
-git commit -asm "Prove the guard fires" && git push -u origin scratch/guard-proof
-gh pr create --base main --title "Scratch: prove the guard" --body "Delete me"
+# The guard fires on a real pull request. specification/proposals/ exists; a README at
+# specification/README.md does not, so creating a new file is what actually produces a
+# diff here.
+git fetch origin integration
+git checkout -b scratch/guard-proof origin/integration
+mkdir -p specification/v0.1.0
+printf 'guard proof, delete me\n' > specification/v0.1.0/GUARD_PROOF.txt
+git add specification/v0.1.0/GUARD_PROOF.txt
+git commit -s -m "Prove the guard fires"
+git push -u origin scratch/guard-proof
+gh pr create --base main --head scratch/guard-proof \
+  --title "Scratch: prove the guard" --body "Delete me"
 ```
 
-Expected: the `base-branch-guard` check fails and names `specification/README.md`. Close the pull request and delete the branch afterward.
+Expected: the `base-branch-guard` check fails and names
+`specification/v0.1.0/GUARD_PROOF.txt`. Then clean up.
+
+```bash
+gh pr close scratch/guard-proof --delete-branch
+```
 
 ```bash
 gh label list --limit 100
@@ -1635,8 +1724,10 @@ Expected: the taxonomy from Step 7, default branch `integration`, three branch r
 
 ## Self-review
 
-**Spec coverage.** Current Priority Scope is Task 5. Branching and the allowlist are Tasks 1, 2, and 5 plus Phase 2 Steps 3, 5, and 6. Labels are Task 3 and Phase 2 Step 7. Issue intake is Task 3. The pull request gate is Tasks 4 and 7. Rulesets are Phase 2 Steps 1 and 5. CODEOWNERS for `reference-implementations/` and `adapters/` is deliberately deferred until #60 and #22 land, since a CODEOWNERS entry for a path that does not exist is inert. Authorship is Task 5. The seeded onramp is Phase 2 Step 9. The sign-up form is specified in the design and is not a repository change. Promotion cadence is Task 7 and Task 6.
+**Spec coverage.** Current Priority Scope is Task 5. Branching and the allowlist are Tasks 1, 2, and 5 plus Phase 2 Steps 3, 5, 6, and 7. Labels are Task 3 and Phase 2 Step 10. Issue intake is Task 3. The pull request gate is Tasks 4 and 7. Rulesets are Phase 2 Steps 1, 4, and 9. CODEOWNERS for `reference-implementations/` and `adapters/` is deliberately deferred until #60 and #22 land, since a CODEOWNERS entry for a path that does not exist is inert. Authorship is Task 5. The seeded onramp is Phase 2 Step 12. The sign-up form is specified in the design and is not a repository change. Promotion cadence is Task 7 and Task 6.
 
-**Placeholders.** None. Every code and configuration step carries its content. Phase 2 Steps 1 and 5 describe ruleset JSON edits rather than pasting the full payload, because the payload is fetched from the live API and edited in place, and a stale copy pasted here would overwrite fields the API added since.
+**Placeholders.** None. Every code and configuration step carries its content. Phase 2 Steps 1, 4, and 9 describe ruleset JSON edits rather than pasting the full payload, because the payload is fetched from the live API and edited in place, and a stale copy pasted here would overwrite fields the API added since.
 
-**Type consistency.** `decide`, `in_docs_lane`, `is_promotion`, and `paths_requiring_integration` carry the same signatures in the test file, the implementation, and the Interfaces block. `is_promotion` takes three arguments everywhere. The job id `base-branch-guard` is identical in Task 2 Step 1, Task 2 Step 3, Phase 2 Step 1, and Phase 2 Step 11. The label strings in Task 3 match those created in Phase 2 Step 7.
+**Type consistency.** `decide`, `in_docs_lane`, `is_promotion`, and `paths_requiring_integration` carry the same signatures in the test file, the implementation, and the Interfaces block. `is_promotion` takes three arguments everywhere. The job id `base-branch-guard` is identical in Task 2 Step 1, Task 2 Step 3, Phase 2 Step 9, and Phase 2 Step 14. The label strings in Task 3 match those created in Phase 2 Step 10.
+
+**Executed, not assumed.** The guard module, its sixteen tests, the `gh label` and `gh repo` flags, the pull-request-count idiom, the PyYAML availability, and the DCO-excluding style check were all run before this plan was finalized. The premortem found six defects that way, including a test that could never pass and a Phase 2 ordering that deadlocked its own pull request.

--- a/design/plans/2026-09-09-contribution-governance.md
+++ b/design/plans/2026-09-09-contribution-governance.md
@@ -1330,9 +1330,9 @@ jobs:
           gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label 'status:needs-triage'
           gh pr comment "$PR_NUMBER" --repo "$REPO" --body "Thanks for this. It is queued rather than ignored.
 
-This pull request does not reference an issue carrying \`status:accepted\`, so a maintainer has not looked at it yet and will not until the underlying issue is triaged. Nothing here is rejected. See [Current Priority Scope](https://github.com/GenAI-Security-Project/agent-control-standard/blob/main/CONTRIBUTING.md#current-priority-scope) for what the project is working on, and [\`help wanted\`](https://github.com/GenAI-Security-Project/agent-control-standard/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) for work that is already accepted.
+          This pull request does not reference an issue carrying \`status:accepted\`, so a maintainer has not looked at it yet and will not until the underlying issue is triaged. Nothing here is rejected. See [Current Priority Scope](https://github.com/GenAI-Security-Project/agent-control-standard/blob/main/CONTRIBUTING.md#current-priority-scope) for what the project is working on, and [\`help wanted\`](https://github.com/GenAI-Security-Project/agent-control-standard/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) for work that is already accepted.
 
-If this is an editorial correction, tick that box in the description and this comment stops applying."
+          If this is an editorial correction, tick that box in the description and this comment stops applying."
 ```
 
 - [ ] **Step 4: Remove the Dependabot problem rather than solving it**

--- a/design/plans/2026-09-09-contribution-governance.md
+++ b/design/plans/2026-09-09-contribution-governance.md
@@ -368,7 +368,7 @@ git commit -s -m "Add the guard that keeps specification changes off the publish
 
 **Interfaces:**
 - Consumes: `tools/base_branch_guard.py` from Task 1, invoked as a script with one argument.
-- Produces: a check run named `base-branch-guard`. Phase 2 Task 10 requires that exact string in `protect-main`.
+- Produces: a check run named `base-branch-guard`. Phase 2 Step 10 requires that exact string in `protect-main`.
 
 - [ ] **Step 1: Write the workflow**
 
@@ -439,7 +439,7 @@ Expected: `OK`. It must be `uv run python`: the system `python3` on this machine
 grep -n "^  base-branch-guard:" .github/workflows/pr-base-guard.yml
 ```
 
-Expected: one match. This string is repeated in Phase 2 Task 10.
+Expected: one match. This string is repeated in Phase 2 Step 10.
 
 - [ ] **Step 4: Commit**
 
@@ -463,7 +463,7 @@ git commit -s -m "Run the base branch guard on every pull request to main"
 
 **Interfaces:**
 - Consumes: nothing.
-- Produces: labels `type:bug`, `type:proposal`, `type:refimpl`, `type:conformance`, `type:docs`, and `status:needs-triage`. Phase 2 Task 8 creates them. A form referencing a label that does not exist fails to apply it silently.
+- Produces: labels `type:bug`, `type:proposal`, `type:refimpl`, `type:conformance`, `type:docs`, and `status:needs-triage`. Phase 2 Step 2 creates them. A form referencing a label that does not exist fails to apply it silently.
 
 **Rule for every form:** no form may declare a `scope:`, `priority:`, `workstream:`, or `status:accepted` label. That prohibition is the whole enforcement mechanism for maintainer-only decision labels.
 
@@ -1116,7 +1116,7 @@ git commit -s -m "State the Current Priority Scope and the acceptance gate in CO
 - Modify: `GOVERNANCE.md`
 
 **Interfaces:**
-- Consumes: the label taxonomy from Task 3 and Phase 2 Task 8.
+- Consumes: the label taxonomy from Task 3 and Phase 2 Step 2.
 - Produces: nothing other tasks read.
 
 - [ ] **Step 1: Insert a section after "Workstream leads"**
@@ -1158,7 +1158,7 @@ git commit -s -m "Record who applies decision labels and what minimum triage is"
 - Modify: `.github/workflows/sync_version.yml:8` (the `branches` key)
 
 **Interfaces:**
-- Consumes: the labels `status:accepted` and `status:needs-triage` from Phase 2 Task 8.
+- Consumes: the labels `status:accepted` and `status:needs-triage` from Phase 2 Step 2.
 - Produces: nothing other tasks read.
 
 - [ ] **Step 1: Write `sync-integration.yml`**
@@ -1478,8 +1478,8 @@ git push -u origin feature/contribution-governance
 This diff touches `.github/`, `tools/`, and `tests/`, every one of them off the
 documentation lane. A pull request from here to `main` would fail the guard it is
 installing, so it goes to `integration` instead, and `integration` does not exist until
-Phase 2 Step 3. Opening it against `main` now is the single mistake that would deadlock
-the whole evening. Phase 2 Step 6 opens it correctly.
+Phase 2 Step 4. Opening it against `main` now is the single mistake that would deadlock
+the whole evening. Phase 2 Step 7 opens it correctly.
 
 ---
 
@@ -1504,7 +1504,7 @@ gh api repos/GenAI-Security-Project/agent-control-standard/rulesets/20720988 > /
 # Edit /tmp/protect-main.json:
 #   conditions.ref_name.include: ["refs/heads/main"]
 #   rules[pull_request].parameters.allowed_merge_methods: ["squash","rebase","merge"]
-# Do NOT add base-branch-guard yet. That is Step 9.
+# Do NOT add base-branch-guard yet. That is Step 10.
 # Leave required_approving_review_count at 1. Raising it throttles promotion, which is
 # the operation this whole model exists to serve.
 gh api -X PUT repos/GenAI-Security-Project/agent-control-standard/rulesets/20720988 \
@@ -1515,103 +1515,7 @@ gh api repos/GenAI-Security-Project/agent-control-standard/rulesets/20720988 \
 
 Expected: `["refs/heads/main"]` and `["squash","rebase","merge"]`.
 
-- [ ] **Step 2: Merge the ready pull requests to `main`**
-
-Core-team decision, not an automated step. The sync's plan was merge #21, align #20 with it, then review #22. Doing this before `integration` exists means those pull requests never move.
-
-- [ ] **Step 3: Create `integration` from `main`**
-
-```bash
-git fetch origin main
-git push origin origin/main:refs/heads/integration
-gh api repos/GenAI-Security-Project/agent-control-standard/branches --jq '.[].name'
-```
-
-Expected: `integration` present and identical to `main`.
-
-- [ ] **Step 4: Create `protect-integration` and `protect-release`**
-
-```bash
-gh api -X POST repos/GenAI-Security-Project/agent-control-standard/rulesets \
-  --input /tmp/protect-integration.json
-```
-
-`protect-integration` mirrors the pre-change `protect-main`: target `refs/heads/integration`, one approval, `require_code_owner_review: true`, `dismiss_stale_reviews_on_push: true`, `require_last_push_approval: true`, `required_review_thread_resolution: true`, required checks `test` and `build`, merge methods squash and rebase, plus deletion and non-fast-forward rules.
-
-`protect-release` targets `refs/heads/release/*` with deletion, non-fast-forward, one approval, and the same required checks.
-
-- [ ] **Step 5: Retarget the remaining open pull requests**
-
-Because `integration` and `main` are identical, no diff changes and no contributor redoes work.
-
-```bash
-for n in 63 24 22 60; do
-  gh pr edit "$n" --base integration || echo "skip $n"
-done
-gh pr list --json number,baseRefName --jq '.[] | "#\(.number) -> \(.baseRefName)"'
-```
-
-`#20`, the FAQ, may stay on `main`.
-
-After each retarget, confirm the required checks reported on the new base. Whether a base change re-triggers them is undocumented, and this repository's workflows declare no `pull_request` types. If a check is missing, close and reopen the pull request to force a run. Do not ask the contributor to rebase, which would cost them their existing approvals.
-
-- [ ] **Step 6: Open the Phase 1 pull request against `integration` and merge it**
-
-```bash
-gh pr create --base integration --head feature/contribution-governance \
-  --title "Install the contribution governance for the OWASP re-launch" \
-  --body "Implements design/2026-09-09-contribution-governance-design.md v1.1."
-```
-
-It targets `integration` because the diff touches `.github/`, `tools/`, and `tests/`. Merge it once `test` and `build` pass.
-
-- [ ] **Step 7: Promote to `main`**
-
-This publishes the site with the new `CONTRIBUTING.md` and, just as importantly, puts the guard workflow on `main` so Step 9 has something that can report.
-
-```bash
-gh pr create --base main --head integration --title "Promote integration to main" \
-  --body "Carries the contribution governance to the publishing branch."
-```
-
-Merge with a **merge commit**, not a squash.
-
-```bash
-git fetch origin main && git ls-tree --name-only origin/main .github/workflows/
-```
-
-Expected: `pr-base-guard.yml` present on `main`.
-
-- [ ] **Step 8: Move the default branch to `integration`**
-
-Step 1 must already be done.
-
-```bash
-gh repo edit GenAI-Security-Project/agent-control-standard --default-branch integration
-gh api repos/GenAI-Security-Project/agent-control-standard --jq '.default_branch'
-gh api repos/GenAI-Security-Project/agent-control-standard/rulesets/20720988 \
-  --jq '.conditions.ref_name.include'
-```
-
-Expected: `integration`, and `protect-main` still naming `refs/heads/main`.
-
-- [ ] **Step 9: Add `base-branch-guard` to the required checks on `main`**
-
-Only now. The workflow reached `main` in Step 7, so the check can report.
-
-```bash
-gh api repos/GenAI-Security-Project/agent-control-standard/rulesets/20720988 > /tmp/protect-main.json
-# Add {"context":"base-branch-guard"} to
-# rules[required_status_checks].parameters.required_status_checks
-gh api -X PUT repos/GenAI-Security-Project/agent-control-standard/rulesets/20720988 \
-  --input /tmp/protect-main.json
-gh api repos/GenAI-Security-Project/agent-control-standard/rulesets/20720988 \
-  --jq '[.rules[]|select(.type=="required_status_checks").parameters.required_status_checks[].context]'
-```
-
-Expected: `["test","build","base-branch-guard"]`.
-
-- [ ] **Step 10: Create the label taxonomy**
+- [ ] **Step 2: Create the label taxonomy**
 
 ```bash
 gh label edit bug           --name 'type:bug'        --color 'd73a4a'
@@ -1647,6 +1551,102 @@ done
 ```
 
 Delete only those reporting `0`.
+
+- [ ] **Step 3: Merge the ready pull requests to `main`**
+
+Core-team decision, not an automated step. The sync's plan was merge #21, align #20 with it, then review #22. Doing this before `integration` exists means those pull requests never move.
+
+- [ ] **Step 4: Create `integration` from `main`**
+
+```bash
+git fetch origin main
+git push origin origin/main:refs/heads/integration
+gh api repos/GenAI-Security-Project/agent-control-standard/branches --jq '.[].name'
+```
+
+Expected: `integration` present and identical to `main`.
+
+- [ ] **Step 5: Create `protect-integration` and `protect-release`**
+
+```bash
+gh api -X POST repos/GenAI-Security-Project/agent-control-standard/rulesets \
+  --input /tmp/protect-integration.json
+```
+
+`protect-integration` mirrors the pre-change `protect-main`: target `refs/heads/integration`, one approval, `require_code_owner_review: true`, `dismiss_stale_reviews_on_push: true`, `require_last_push_approval: true`, `required_review_thread_resolution: true`, required checks `test` and `build`, merge methods squash and rebase, plus deletion and non-fast-forward rules.
+
+`protect-release` targets `refs/heads/release/*` with deletion, non-fast-forward, one approval, and the same required checks.
+
+- [ ] **Step 6: Retarget the remaining open pull requests**
+
+Because `integration` and `main` are identical, no diff changes and no contributor redoes work.
+
+```bash
+for n in 63 24 22 60; do
+  gh pr edit "$n" --base integration || echo "skip $n"
+done
+gh pr list --json number,baseRefName --jq '.[] | "#\(.number) -> \(.baseRefName)"'
+```
+
+`#20`, the FAQ, may stay on `main`.
+
+After each retarget, confirm the required checks reported on the new base. Whether a base change re-triggers them is undocumented, and this repository's workflows declare no `pull_request` types. If a check is missing, close and reopen the pull request to force a run. Do not ask the contributor to rebase, which would cost them their existing approvals.
+
+- [ ] **Step 7: Open the Phase 1 pull request against `integration` and merge it**
+
+```bash
+gh pr create --base integration --head feature/contribution-governance \
+  --title "Install the contribution governance for the OWASP re-launch" \
+  --body "Implements design/2026-09-09-contribution-governance-design.md v1.1."
+```
+
+It targets `integration` because the diff touches `.github/`, `tools/`, and `tests/`. Merge it once `test` and `build` pass.
+
+- [ ] **Step 8: Promote to `main`**
+
+This publishes the site with the new `CONTRIBUTING.md` and, just as importantly, puts the guard workflow on `main` so Step 10 has something that can report.
+
+```bash
+gh pr create --base main --head integration --title "Promote integration to main" \
+  --body "Carries the contribution governance to the publishing branch."
+```
+
+Merge with a **merge commit**, not a squash.
+
+```bash
+git fetch origin main && git ls-tree --name-only origin/main .github/workflows/
+```
+
+Expected: `pr-base-guard.yml` present on `main`.
+
+- [ ] **Step 9: Move the default branch to `integration`**
+
+Step 1 must already be done.
+
+```bash
+gh repo edit GenAI-Security-Project/agent-control-standard --default-branch integration
+gh api repos/GenAI-Security-Project/agent-control-standard --jq '.default_branch'
+gh api repos/GenAI-Security-Project/agent-control-standard/rulesets/20720988 \
+  --jq '.conditions.ref_name.include'
+```
+
+Expected: `integration`, and `protect-main` still naming `refs/heads/main`.
+
+- [ ] **Step 10: Add `base-branch-guard` to the required checks on `main`**
+
+Only now. The workflow reached `main` in Step 8, so the check can report.
+
+```bash
+gh api repos/GenAI-Security-Project/agent-control-standard/rulesets/20720988 > /tmp/protect-main.json
+# Add {"context":"base-branch-guard"} to
+# rules[required_status_checks].parameters.required_status_checks
+gh api -X PUT repos/GenAI-Security-Project/agent-control-standard/rulesets/20720988 \
+  --input /tmp/protect-main.json
+gh api repos/GenAI-Security-Project/agent-control-standard/rulesets/20720988 \
+  --jq '[.rules[]|select(.type=="required_status_checks").parameters.required_status_checks[].context]'
+```
+
+Expected: `["test","build","base-branch-guard"]`.
 
 - [ ] **Step 11: Create the milestones**
 
@@ -1724,10 +1724,10 @@ Expected: the taxonomy from Step 7, default branch `integration`, three branch r
 
 ## Self-review
 
-**Spec coverage.** Current Priority Scope is Task 5. Branching and the allowlist are Tasks 1, 2, and 5 plus Phase 2 Steps 3, 5, 6, and 7. Labels are Task 3 and Phase 2 Step 10. Issue intake is Task 3. The pull request gate is Tasks 4 and 7. Rulesets are Phase 2 Steps 1, 4, and 9. CODEOWNERS for `reference-implementations/` and `adapters/` is deliberately deferred until #60 and #22 land, since a CODEOWNERS entry for a path that does not exist is inert. Authorship is Task 5. The seeded onramp is Phase 2 Step 12. The sign-up form is specified in the design and is not a repository change. Promotion cadence is Task 7 and Task 6.
+**Spec coverage.** Current Priority Scope is Task 5. Branching and the allowlist are Tasks 1, 2, and 5 plus Phase 2 Steps 4, 6, 7, and 8. Labels are Task 3 and Phase 2 Step 2. Issue intake is Task 3. The pull request gate is Tasks 4 and 7. Rulesets are Phase 2 Steps 1, 5, and 10. CODEOWNERS for `reference-implementations/` and `adapters/` is deliberately deferred until #60 and #22 land, since a CODEOWNERS entry for a path that does not exist is inert. Authorship is Task 5. The seeded onramp is Phase 2 Step 12. The sign-up form is specified in the design and is not a repository change. Promotion cadence is Task 7 and Task 6.
 
-**Placeholders.** None. Every code and configuration step carries its content. Phase 2 Steps 1, 4, and 9 describe ruleset JSON edits rather than pasting the full payload, because the payload is fetched from the live API and edited in place, and a stale copy pasted here would overwrite fields the API added since.
+**Placeholders.** None. Every code and configuration step carries its content. Phase 2 Steps 1, 5, and 10 describe ruleset JSON edits rather than pasting the full payload, because the payload is fetched from the live API and edited in place, and a stale copy pasted here would overwrite fields the API added since.
 
-**Type consistency.** `decide`, `in_docs_lane`, `is_promotion`, and `paths_requiring_integration` carry the same signatures in the test file, the implementation, and the Interfaces block. `is_promotion` takes three arguments everywhere. The job id `base-branch-guard` is identical in Task 2 Step 1, Task 2 Step 3, Phase 2 Step 9, and Phase 2 Step 14. The label strings in Task 3 match those created in Phase 2 Step 10.
+**Type consistency.** `decide`, `in_docs_lane`, `is_promotion`, and `paths_requiring_integration` carry the same signatures in the test file, the implementation, and the Interfaces block. `is_promotion` takes three arguments everywhere. The job id `base-branch-guard` is identical in Task 2 Step 1, Task 2 Step 3, Phase 2 Step 10, and Phase 2 Step 14. The label strings in Task 3 match those created in Phase 2 Step 2.
 
 **Executed, not assumed.** The guard module, its sixteen tests, the `gh label` and `gh repo` flags, the pull-request-count idiom, the PyYAML availability, and the DCO-excluding style check were all run before this plan was finalized. The premortem found six defects that way, including a test that could never pass and a Phase 2 ordering that deadlocked its own pull request.

--- a/design/plans/2026-09-09-contribution-governance.md
+++ b/design/plans/2026-09-09-contribution-governance.md
@@ -1623,7 +1623,11 @@ done
 gh pr list --json number,baseRefName --jq '.[] | "#\(.number) -> \(.baseRefName)"'
 ```
 
-`#20`, the FAQ, may stay on `main`.
+`#20` moves too. Its title says FAQ and its prose is documentation, so it reads like a
+candidate for the documentation lane, and it is not: it also edits `mkdocs.yml`, which is
+excluded because it accepts a `hooks:` key that executes Python inside the build job. This
+was asserted from the title in an earlier draft and only caught by running the guard against
+the real file list. Check the files, never the title.
 
 After each retarget, confirm the required checks reported on the new base. Whether a base change re-triggers them is undocumented, and this repository's workflows declare no `pull_request` types. If a check is missing, close and reopen the pull request to force a run. Do not ask the contributor to rebase, which would cost them their existing approvals.
 

--- a/landing/assets/acs.css
+++ b/landing/assets/acs.css
@@ -218,6 +218,18 @@ section:first-of-type { border-top: 0; }
 .card { padding: 1.5rem; border: 1px solid var(--acs-border); border-radius: 14px; background-color: var(--acs-surface); }
 .card h3 { margin-top: 0; }
 
+/* Reuses the tier accent-border pattern so the committed outcome reads as a callout,
+   not as a quoted aside, without adding a second visual language to the page. */
+blockquote {
+  margin: 1.5rem 0;
+  padding: 1rem 1.5rem;
+  border-left: 4px solid var(--acs-accent-navy);
+  border-radius: 0 12px 12px 0;
+  background-color: var(--acs-surface);
+  color: var(--acs-text-soft);
+  font-style: italic;
+}
+
 .standards {
   list-style: none;
   padding: 0;
@@ -249,7 +261,8 @@ section:first-of-type { border-top: 0; }
    standards grids set their own widths and are excluded. */
 main section > p,
 main section > ul:not(.standards),
-main section > table { max-width: 72ch; }
+main section > table,
+main section > blockquote { max-width: 72ch; }
 
 .tier { border-left: 4px solid var(--acs-border-strong); padding-left: 1rem; margin-bottom: 1.25rem; }
 .tier-1 { border-left-color: var(--acs-tier-1); }

--- a/landing/index.html
+++ b/landing/index.html
@@ -189,13 +189,22 @@
 
     <section id="contribute">
       <h2>Contribute</h2>
-      <p>ACS is an open specification. The fastest way to shape it is to use it and tell
-      us what breaks.</p>
+      <p>ACS is working toward one committed outcome right now, and contributions are
+      accepted against that outcome rather than against an open-ended list of ideas.</p>
+      <blockquote id="priority-scope"><!--ACS:PRIORITY_SCOPE--></blockquote>
+      <p>Read the
+      <a href="https://github.com/GenAI-Security-Project/agent-control-standard/blob/main/CONTRIBUTING.md#current-priority-scope">full
+      priority scope</a> before you file anything. Work that a maintainer has already
+      accepted carries the
+      <a href="https://github.com/GenAI-Security-Project/agent-control-standard/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22"><code>help
+      wanted</code> label</a> and needs no triage wait.</p>
       <ul>
         <li>Join <a href="https://owasp.slack.com">owasp.slack.com</a> and the
         <code>#team-genai-asi-acs-general</code> channel.</li>
-        <li>Open an issue or a discussion on
-        <a href="https://github.com/GenAI-Security-Project/agent-control-standard">GitHub</a>.</li>
+        <li>Propose new work through the
+        <a href="https://github.com/GenAI-Security-Project/agent-control-standard/issues/new/choose">issue
+        forms</a>. Only an issue a maintainer marks <code>status:accepted</code> enters
+        the backlog.</li>
         <li>General questions about the project:
         <a href="mailto:rock.lambros@owasp.org">rock.lambros@owasp.org</a></li>
       </ul>

--- a/tests/test_apply_governance.py
+++ b/tests/test_apply_governance.py
@@ -259,6 +259,73 @@ def test_ruleset_payload_includes_bypass_actors_at_top_level():
         )
 
 
+def test_required_status_checks_rule_carries_strict_and_enforce_fields():
+    """Every ruleset payload must include strict_required_status_checks_policy and
+    do_not_enforce_on_create in the required_status_checks rule parameters.
+
+    GitHub's ruleset API returns HTTP 422 with error message naming only the rule
+    index (/rules/3) rather than the missing field when these parameters are absent.
+    This opaque error is why the discovery overhead of a failing test here is worth
+    it: a later breakage will surface immediately, not as a cryptic 422 after
+    someone reruns the tool.
+    """
+    from apply_governance import _ruleset_payload
+
+    for ruleset in desired_rulesets():
+        payload = _ruleset_payload(ruleset)
+        # Find the required_status_checks rule
+        required_checks_rules = [
+            rule for rule in payload.get("rules", [])
+            if rule.get("type") == "required_status_checks"
+        ]
+        assert required_checks_rules, (
+            f"payload for {ruleset.name!r} has no required_status_checks rule"
+        )
+        rule = required_checks_rules[0]
+        params = rule.get("parameters", {})
+        assert "strict_required_status_checks_policy" in params, (
+            f"payload for {ruleset.name!r} required_status_checks rule is missing "
+            f"strict_required_status_checks_policy"
+        )
+        assert "do_not_enforce_on_create" in params, (
+            f"payload for {ruleset.name!r} required_status_checks rule is missing "
+            f"do_not_enforce_on_create"
+        )
+        assert params["strict_required_status_checks_policy"] is False, (
+            f"strict_required_status_checks_policy for {ruleset.name!r} should be False"
+        )
+        assert params["do_not_enforce_on_create"] is False, (
+            f"do_not_enforce_on_create for {ruleset.name!r} should be False"
+        )
+
+
+def test_required_status_checks_parameters_contains_exactly_three_keys():
+    """The required_status_checks rule parameters must contain exactly the three
+    expected keys: required_status_checks, strict_required_status_checks_policy, and
+    do_not_enforce_on_create. A stray key could trigger the same 422 error from the
+    other direction."""
+    from apply_governance import _ruleset_payload
+
+    expected_keys = {
+        "required_status_checks",
+        "strict_required_status_checks_policy",
+        "do_not_enforce_on_create"
+    }
+    for ruleset in desired_rulesets():
+        payload = _ruleset_payload(ruleset)
+        required_checks_rules = [
+            rule for rule in payload.get("rules", [])
+            if rule.get("type") == "required_status_checks"
+        ]
+        rule = required_checks_rules[0]
+        params = rule.get("parameters", {})
+        actual_keys = set(params.keys())
+        assert actual_keys == expected_keys, (
+            f"payload for {ruleset.name!r} required_status_checks parameters has "
+            f"keys {actual_keys} but expected exactly {expected_keys}"
+        )
+
+
 # --- plan_actions: idempotence and completeness ---------------------------------
 
 def _live_matching(desired) -> dict:

--- a/tests/test_apply_governance.py
+++ b/tests/test_apply_governance.py
@@ -1,0 +1,350 @@
+"""Tests for the Phase 2 governance executor.
+
+Everything here is a pure-function test. None of it shells out to `gh`, opens a
+socket, or touches the live OWASP repository: the whole point of structuring
+apply_governance.py as desired-state functions plus a diff is that the diff is
+testable without either.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+# Matches the import style the other tools tests use, in test_publish_schemas.py:12.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+
+from apply_governance import (  # noqa: E402
+    AUTOMATABLE_STEPS,
+    HUMAN_STEPS,
+    Ruleset,
+    build_parser,
+    collect_actions,
+    desired_issues,
+    desired_labels,
+    desired_milestones,
+    desired_rulesets,
+    desired_state,
+    main,
+    plan_actions,
+    plan_branch_actions,
+    plan_default_branch_actions,
+    plan_required_check_actions,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ISSUE_TEMPLATE_DIR = REPO_ROOT / ".github" / "ISSUE_TEMPLATE"
+
+FORBIDDEN_ARGV_SUBSTRINGS = ("pr merge", "pr close", "pr edit", "label delete")
+
+FIVE_AXES = ("type:", "scope:", "status:", "priority:", "workstream:")
+STOCK_DEFAULTS = {"help wanted", "good first issue"}
+
+
+# --- Label taxonomy -----------------------------------------------------------
+
+def test_label_taxonomy_is_exactly_the_five_axes_plus_stock_defaults():
+    for label in desired_labels():
+        assert label.name.startswith(FIVE_AXES) or label.name in STOCK_DEFAULTS, (
+            f"{label.name!r} is outside the five axes and the two stock defaults"
+        )
+
+
+def test_renames_are_distinct_from_creates():
+    renames = {label.rename_from: label for label in desired_labels() if label.rename_from}
+    assert set(renames) == {"bug", "documentation", "enhancement"}
+    assert renames["bug"].name == "type:bug" and renames["bug"].color == "d73a4a"
+    assert renames["documentation"].name == "type:docs" and renames["documentation"].color == "0075ca"
+    assert renames["enhancement"].name == "type:proposal" and renames["enhancement"].color == "a2eeef"
+
+    created_names = {label.name for label in desired_labels() if not label.rename_from}
+    # A create must never collide with a name a rename target already owns.
+    assert created_names.isdisjoint(renames[k].name for k in renames)
+
+
+def _labels_declared_in_issue_forms() -> list[str]:
+    """Parse every `labels:` line out of the real issue form files.
+
+    A form referencing a label the tool never creates fails to apply it silently, per
+    the plan's Task 3 Interfaces note, so this reads the actual files rather than a
+    fixture that could drift from them.
+    """
+    pattern = re.compile(r"^labels:\s*(\[.*\])\s*$")
+    declared: list[str] = []
+    for path in sorted(ISSUE_TEMPLATE_DIR.glob("*.yml")):
+        for line in path.read_text(encoding="utf-8").splitlines():
+            match = pattern.match(line.strip())
+            if match:
+                declared.extend(json.loads(match.group(1)))
+    return declared
+
+
+def test_issue_form_labels_are_all_in_the_desired_taxonomy():
+    declared = _labels_declared_in_issue_forms()
+    assert declared, "expected at least one labels: line under .github/ISSUE_TEMPLATE"
+    taxonomy = {label.name for label in desired_labels()}
+    for name in declared:
+        assert name in taxonomy, f"{name!r} is stamped by a form but never created by the tool"
+
+
+def test_issue_forms_never_stamp_a_decision_label():
+    """No form may apply scope:, priority:, workstream:, or status:accepted.
+
+    That prohibition, not code, is the whole enforcement mechanism for maintainer-only
+    decision labels, so it is worth asserting on the forms directly and not just on
+    the taxonomy the tool creates.
+    """
+    decision_prefixes = ("scope:", "priority:", "workstream:")
+    for name in _labels_declared_in_issue_forms():
+        assert not name.startswith(decision_prefixes), f"a form stamps decision label {name!r}"
+        assert name != "status:accepted", "a form stamps status:accepted"
+
+
+# --- Milestones -----------------------------------------------------------------
+
+def test_milestone_due_dates_are_exact():
+    due_dates = {milestone.title: milestone.due_on for milestone in desired_milestones()}
+    assert due_dates == {
+        "Day 14": "2026-09-24",
+        "Day 30": "2026-10-09",
+        "Day 60": "2026-11-06",
+        "Day 90": "2026-12-04",
+    }
+
+
+# --- Issues -----------------------------------------------------------------------
+
+def test_desired_issues_returns_sixteen():
+    assert len(desired_issues()) == 16
+
+
+def test_every_seeded_onramp_issue_carries_the_three_onramp_labels():
+    """An issue carrying help wanted is one of the 9 seeded onramp issues.
+
+    Checked this way, rather than by slicing the first 9, so the assertion survives
+    desired_issues() being reordered: the label combination is the actual contract,
+    not the position in the list.
+    """
+    onramp = [issue for issue in desired_issues() if "help wanted" in issue.labels]
+    assert len(onramp) == 9
+    for issue in onramp:
+        assert "scope:in-focus" in issue.labels
+        assert "status:accepted" in issue.labels
+
+
+def test_tracked_followups_are_the_remaining_seven():
+    followups = [issue for issue in desired_issues() if "help wanted" not in issue.labels]
+    assert len(followups) == 7
+    for issue in followups:
+        assert "scope:in-focus" not in issue.labels
+
+
+def test_issue_labels_are_all_in_the_desired_taxonomy():
+    taxonomy = {label.name for label in desired_labels()}
+    for issue in desired_issues():
+        for name in issue.labels:
+            assert name in taxonomy, f"issue {issue.title!r} uses undeclared label {name!r}"
+
+
+def test_issue_milestones_when_set_name_a_desired_milestone():
+    milestone_titles = {milestone.title for milestone in desired_milestones()}
+    for issue in desired_issues():
+        if issue.milestone is not None:
+            assert issue.milestone in milestone_titles
+
+
+# --- Rulesets -----------------------------------------------------------------
+
+def test_desired_rulesets_are_protect_integration_and_protect_release():
+    rulesets = {ruleset.name: ruleset for ruleset in desired_rulesets()}
+    assert set(rulesets) == {"protect-integration", "protect-release"}
+    assert rulesets["protect-integration"].target_ref == "refs/heads/integration"
+    assert rulesets["protect-release"].target_ref == "refs/heads/release/*"
+    for ruleset in rulesets.values():
+        assert ruleset.required_approving_review_count == 1
+        assert ruleset.require_code_owner_review is True
+        assert ruleset.dismiss_stale_reviews_on_push is True
+        assert ruleset.require_last_push_approval is True
+        assert ruleset.required_review_thread_resolution is True
+        assert ruleset.required_status_checks == ("test", "build")
+        assert ruleset.allowed_merge_methods == ("squash", "rebase")
+
+
+# --- plan_actions: idempotence and completeness ---------------------------------
+
+def _live_matching(desired) -> dict:
+    """Build a live-state dict that already satisfies every desired object.
+
+    Used to prove idempotence: feeding this back into plan_actions must return an
+    empty list, because there is nothing left for the tool to do.
+    """
+    return {
+        "labels": [
+            {
+                "name": label.name,
+                "color": label.color,
+                "description": label.description if label.description is not None else "",
+            }
+            for label in desired.labels
+        ],
+        "milestones": [
+            {"title": m.title, "due_on": m.due_on, "description": m.description, "number": i}
+            for i, m in enumerate(desired.milestones)
+        ],
+        "issues": [
+            {"title": issue.title, "body": issue.body, "labels": list(issue.labels)}
+            for issue in desired.issues
+        ],
+        "rulesets": [asdict(ruleset) for ruleset in desired.rulesets],
+    }
+
+
+def test_plan_actions_is_idempotent_against_matching_live_state():
+    desired = desired_state()
+    live = _live_matching(desired)
+    assert plan_actions(live, desired) == []
+
+
+def test_plan_actions_against_empty_live_state_returns_one_action_per_desired_object():
+    desired = desired_state()
+    empty_live = {"labels": [], "milestones": [], "issues": [], "rulesets": []}
+    actions = plan_actions(empty_live, desired)
+    expected_count = (
+        len(desired.labels) + len(desired.milestones) + len(desired.issues) + len(desired.rulesets)
+    )
+    assert len(actions) == expected_count
+
+
+def test_plan_actions_against_missing_keys_behaves_like_empty_live_state():
+    """live_state.get(..., []) means a caller who fetched nothing gets full actions,
+    not a crash."""
+    desired = desired_state()
+    assert len(plan_actions({}, desired)) == len(plan_actions(
+        {"labels": [], "milestones": [], "issues": [], "rulesets": []}, desired
+    ))
+
+
+def test_label_rename_is_detected_even_when_the_old_name_is_still_live():
+    """A live label still named `bug` produces a rename action, not a create."""
+    desired = desired_state()
+    live = _live_matching(desired)
+    live["labels"] = [
+        entry for entry in live["labels"] if entry["name"] != "type:bug"
+    ] + [{"name": "bug", "color": "d73a4a", "description": "Something isn't working"}]
+    actions = plan_actions(live, desired)
+    label_actions = [a for a in actions if a.step == "labels"]
+    assert len(label_actions) == 1
+    assert "bug" in label_actions[0].argv
+    assert "edit" in label_actions[0].argv
+    assert "create" not in label_actions[0].argv
+
+
+# --- Singleton steps: branch, default-branch, required-check --------------------
+
+def test_branch_action_only_fires_when_integration_is_missing():
+    assert plan_branch_actions({"branches": ["main"]}) != []
+    assert plan_branch_actions({"branches": ["main", "integration"]}) == []
+
+
+def test_default_branch_action_only_fires_when_not_already_integration():
+    assert plan_default_branch_actions({"default_branch": "main"}) != []
+    assert plan_default_branch_actions({"default_branch": "integration"}) == []
+
+
+def test_required_check_action_only_fires_when_the_check_is_missing():
+    without_check = {
+        "protect_main": {"id": 1, "required_status_checks": ("test", "build")}
+    }
+    with_check = {
+        "protect_main": {"id": 1, "required_status_checks": ("test", "build", "base-branch-guard")}
+    }
+    assert plan_required_check_actions(without_check) != []
+    assert plan_required_check_actions(with_check) == []
+    assert plan_required_check_actions({}) == []
+
+
+# --- SAFETY: the tool cannot merge, close, retarget a PR, or delete a label -----
+
+def _all_actions_for_safety_scan() -> list:
+    """Every action this tool can render, across every planner, for both an empty
+    and an already-satisfied live state. This is the "full desired state, not a
+    sample" the safety property has to hold over.
+    """
+    desired = desired_state()
+    matching_live = _live_matching(desired)
+    matching_live["branches"] = ["main", "integration"]
+    matching_live["default_branch"] = "integration"
+    matching_live["protect_main"] = {
+        "id": 1, "required_status_checks": ("test", "build", "base-branch-guard"),
+    }
+
+    empty_live: dict = {"labels": [], "milestones": [], "issues": [], "rulesets": []}
+    empty_live["branches"] = []
+    empty_live["default_branch"] = "main"
+    empty_live["protect_main"] = {"id": 1, "required_status_checks": ("test", "build")}
+
+    actions = []
+    for live in (matching_live, empty_live):
+        actions += collect_actions(live)
+    return actions
+
+
+def test_no_action_ever_merges_closes_edits_a_pr_or_deletes_a_label():
+    actions = _all_actions_for_safety_scan()
+    assert actions, "expected at least one action to scan"
+    for action in actions:
+        rendered = " ".join(action.argv)
+        for forbidden in FORBIDDEN_ARGV_SUBSTRINGS:
+            assert forbidden not in rendered, (
+                f"action {action.description!r} renders forbidden command fragment "
+                f"{forbidden!r}: {action.argv}"
+            )
+
+
+def test_the_module_source_never_spells_a_forbidden_gh_subcommand():
+    """Belt and braces on top of the behavioral scan: the literal strings never
+    appear anywhere in the module, so no code path, reachable or not, can emit them.
+    """
+    source = (REPO_ROOT / "tools" / "apply_governance.py").read_text(encoding="utf-8")
+    for forbidden in FORBIDDEN_ARGV_SUBSTRINGS:
+        assert forbidden not in source, f"module source contains {forbidden!r}"
+
+
+# --- CLI --------------------------------------------------------------------------
+
+def test_dry_run_is_the_default_and_apply_is_a_separate_flag():
+    args = build_parser().parse_args([])
+    assert args.apply is False
+    args = build_parser().parse_args(["--apply"])
+    assert args.apply is True
+
+
+def test_only_accepts_a_step_name():
+    args = build_parser().parse_args(["--only", "labels"])
+    assert args.only == "labels"
+
+
+def test_main_refuses_a_human_only_step_without_touching_the_network():
+    for step in HUMAN_STEPS:
+        status = main(["--only", step])
+        assert status != 0
+
+
+def test_main_refuses_an_unknown_step():
+    status = main(["--only", "definitely-not-a-real-step"])
+    assert status != 0
+
+
+def test_automatable_steps_and_human_steps_do_not_overlap():
+    assert set(AUTOMATABLE_STEPS).isdisjoint(HUMAN_STEPS)
+
+
+def test_plan_step_3_6_7_are_represented_among_the_human_steps():
+    """The plan calls out Steps 3, 6, and 7 by name as staying human. This asserts
+    the tool actually says so for something shaped like each of them, rather than
+    just being silent."""
+    assert "merge-ready-prs" in HUMAN_STEPS
+    assert "retarget-prs" in HUMAN_STEPS
+    assert "merge-phase1-pr" in HUMAN_STEPS

--- a/tests/test_apply_governance.py
+++ b/tests/test_apply_governance.py
@@ -155,6 +155,38 @@ def test_issue_milestones_when_set_name_a_desired_milestone():
             assert issue.milestone in milestone_titles
 
 
+def test_no_seeded_issue_carries_priority_p0():
+    """P0 is reserved for the serial chain: the floor decision, adapters, Guardian, and
+    benchmark. GOVERNANCE.md lines 32-34 enforce this rule. The only P0 issues are PR
+    #21 (the floor decision) and PR #22 (the adapters), which are pull requests rather
+    than seeded issues. Runtime ports and other work are valuable but carry P1."""
+    p0_issues = []
+    for issue in desired_issues():
+        if "priority:P0" in issue.labels:
+            p0_issues.append(issue.title)
+    assert not p0_issues, (
+        f"The following issues carry priority:P0 but should not: {p0_issues}. "
+        f"GOVERNANCE.md reserves P0 for the serial chain links: the floor decision "
+        f"(PR #21), adapters (PR #22), the installable Guardian, and the interoperability "
+        f"benchmark. Runtime ports and other work are P1."
+    )
+
+
+def test_all_nine_seeded_issues_carry_scope_status_and_help_wanted():
+    """The nine seeded onramp issues must all carry scope:in-focus, status:accepted, and
+    help wanted. These three labels signal to contributors that the work is ready to
+    start without waiting on triage."""
+    required_labels = {"scope:in-focus", "status:accepted", "help wanted"}
+    seeded = [issue for issue in desired_issues() if "help wanted" in issue.labels]
+    assert len(seeded) == 9, f"expected 9 seeded onramp issues, found {len(seeded)}"
+    for issue in seeded:
+        issue_labels = set(issue.labels)
+        missing = required_labels - issue_labels
+        assert not missing, (
+            f"issue {issue.title!r} is missing labels {missing}"
+        )
+
+
 # --- Rulesets -----------------------------------------------------------------
 
 def test_desired_rulesets_are_protect_integration_and_protect_release():

--- a/tests/test_apply_governance.py
+++ b/tests/test_apply_governance.py
@@ -172,6 +172,61 @@ def test_desired_rulesets_are_protect_integration_and_protect_release():
         assert ruleset.allowed_merge_methods == ("squash", "rebase")
 
 
+def test_every_ruleset_carries_admin_bypass():
+    """Every ruleset must carry a bypass entry for RepositoryRole 5 (admin).
+
+    Without it, a sole maintainer cannot merge into a branch requiring review,
+    because GitHub does not let anyone approve their own pull request. When that
+    maintainer is the only one awake the night before a public relaunch, a missing
+    bypass means the workflow that installs this very tool becomes unmergeable the
+    instant the protected branch is created, halting the migration halfway through.
+    """
+    for ruleset in desired_rulesets():
+        assert ruleset.bypass_actors is not None, (
+            f"ruleset {ruleset.name!r} has no bypass_actors"
+        )
+        # Check it has at least one entry for admin role
+        admin_bypasses = [
+            entry for entry in ruleset.bypass_actors
+            if entry.get("actor_id") == 5
+            and entry.get("actor_type") == "RepositoryRole"
+            and entry.get("bypass_mode") == "always"
+        ]
+        assert admin_bypasses, (
+            f"ruleset {ruleset.name!r} has bypass_actors but no entry for "
+            f"RepositoryRole 5 with always mode"
+        )
+
+
+def test_ruleset_payload_includes_bypass_actors_at_top_level():
+    """The rendered payload must include bypass_actors at the top level.
+
+    A bypass buried inside rules goes unrecognized and does not grant the expected
+    override, leaving the maintainer in the lockout scenario described above.
+    """
+    from apply_governance import _ruleset_payload
+
+    for ruleset in desired_rulesets():
+        payload = _ruleset_payload(ruleset)
+        assert "bypass_actors" in payload, (
+            f"payload for {ruleset.name!r} has no top-level bypass_actors field"
+        )
+        assert isinstance(payload["bypass_actors"], list), (
+            f"bypass_actors in {ruleset.name!r} payload is not a list"
+        )
+        # Check that at least one entry is for admin role
+        admin_entries = [
+            entry for entry in payload["bypass_actors"]
+            if entry.get("actor_id") == 5
+            and entry.get("actor_type") == "RepositoryRole"
+            and entry.get("bypass_mode") == "always"
+        ]
+        assert admin_entries, (
+            f"payload for {ruleset.name!r} has bypass_actors but no admin "
+            f"RepositoryRole 5 entry"
+        )
+
+
 # --- plan_actions: idempotence and completeness ---------------------------------
 
 def _live_matching(desired) -> dict:

--- a/tests/test_base_branch_guard.py
+++ b/tests/test_base_branch_guard.py
@@ -1,0 +1,135 @@
+"""Guards for the rule that keeps specification and code off the publishing branch.
+
+The allowlist is positive, so the interesting cases are the ones nobody enumerated. A
+directory that did not exist when the list was written has to fail, and a fork branch
+named like a promotion branch has to fail, because both are how an allowlist quietly
+turns into a blocklist.
+"""
+
+import sys
+from pathlib import Path
+
+# Matches the import style the other tools tests use, in test_publish_schemas.py:12.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
+
+from base_branch_guard import (  # noqa: E402
+    PUBLISHING_BRANCH,
+    decide,
+    in_docs_lane,
+    is_promotion,
+    paths_requiring_integration,
+)
+
+REPO = "GenAI-Security-Project/agent-control-standard"
+FORK = "someone/agent-control-standard"
+
+
+def test_allowlisted_documentation_path_is_in_the_lane():
+    assert in_docs_lane("docs/topics/core_concepts.md")
+    assert in_docs_lane("CONTRIBUTING.md")
+    assert in_docs_lane("design/2026-09-09-contribution-governance-design.md")
+
+
+def test_specification_paths_are_not_in_the_lane():
+    assert not in_docs_lane("specification/v0.1.0/acs_schema.json")
+    assert not in_docs_lane("docs/spec/instrument/hooks.md")
+
+
+def test_normative_concept_prose_is_not_in_the_lane():
+    """Concept pages define the terms the specification uses, so they travel with it."""
+    assert not in_docs_lane("docs/concepts/capability.md")
+    assert not in_docs_lane("docs/identity/standards.md")
+
+
+def test_build_surfaces_are_not_in_the_lane():
+    """A reader calls these documentation. Each one reaches code or a third party."""
+    assert not in_docs_lane("mkdocs.yml")
+    assert not in_docs_lane("overrides/main.html")
+    assert not in_docs_lane("landing/index.html")
+    assert not in_docs_lane("docs/stylesheets/extra.css")
+    assert not in_docs_lane("docs/assets/logo.svg")
+
+
+def test_directory_matching_requires_the_separator():
+    """A prefix check without the slash reads docs/specimen.md as docs/spec."""
+    assert in_docs_lane("docs/topics/anything.md")
+    assert not in_docs_lane("docs/topicsextra.md")
+
+
+def test_an_unanticipated_directory_fails_closed():
+    assert not in_docs_lane("reference-implementations/agt/main.ts")
+    assert not in_docs_lane("something/nobody/planned.txt")
+
+
+def test_paths_requiring_integration_returns_only_offenders_sorted():
+    changed = ["CONTRIBUTING.md", "specification/a.json", "docs/spec/b.md"]
+    assert paths_requiring_integration(changed) == [
+        "docs/spec/b.md",
+        "specification/a.json",
+    ]
+
+
+def test_promotion_from_integration_in_this_repository():
+    assert is_promotion("integration", REPO, REPO)
+
+
+def test_promotion_from_a_release_branch_in_this_repository():
+    assert is_promotion("release/v0.2.0", REPO, REPO)
+
+
+def test_a_fork_branch_named_integration_is_not_a_promotion():
+    """head.ref is a name the contributor chose. Only the repository check is trustworthy."""
+    assert not is_promotion("integration", FORK, REPO)
+    assert not is_promotion("release/v0.2.0", FORK, REPO)
+
+
+def test_documentation_only_pull_request_to_main_passes():
+    status, message = decide(["docs/topics/faq.md"], PUBLISHING_BRANCH, "docs/faq", FORK, REPO)
+    assert status == 0
+    assert "documentation lane" in message
+
+
+def test_specification_pull_request_to_main_fails_and_names_the_file():
+    status, message = decide(
+        ["specification/v0.1.0/acs_schema.json"], PUBLISHING_BRANCH, "spec/x", FORK, REPO
+    )
+    assert status == 1
+    assert "specification/v0.1.0/acs_schema.json" in message
+    assert "integration" in message
+
+
+def test_mixed_diff_fails():
+    """Only the offenders appear in the listing.
+
+    The assertion reads the listing rather than the whole message on purpose. The
+    message ends with "See CONTRIBUTING.md.", so a naive `not in message` check can
+    never pass and would push somebody into changing the guard to satisfy the test.
+    """
+    status, message = decide(
+        ["CONTRIBUTING.md", "specification/a.json"], PUBLISHING_BRANCH, "mix", FORK, REPO
+    )
+    listing = message.split("\n\n")[0]
+    assert status == 1
+    assert "specification/a.json" in listing
+    assert "CONTRIBUTING.md" not in listing
+
+
+def test_promotion_passes_with_specification_paths():
+    status, message = decide(
+        ["specification/a.json"], PUBLISHING_BRANCH, "integration", REPO, REPO
+    )
+    assert status == 0
+    assert "Promotion" in message
+
+
+def test_any_other_base_passes_without_consulting_the_allowlist():
+    status, message = decide(
+        ["specification/a.json"], "integration", "spec/x", FORK, REPO
+    )
+    assert status == 0
+    assert "Nothing to check" in message
+
+
+def test_an_empty_diff_passes():
+    status, _ = decide([], PUBLISHING_BRANCH, "empty", FORK, REPO)
+    assert status == 0

--- a/tests/test_landing_page.py
+++ b/tests/test_landing_page.py
@@ -23,6 +23,7 @@ def page() -> str:
         (LANDING / "index.html").read_text(encoding="utf-8"),
         REPO / "specification",
         (REPO / "GOVERNANCE.md").read_text(encoding="utf-8"),
+        (REPO / "CONTRIBUTING.md").read_text(encoding="utf-8"),
         (LANDING / "assets" / "starburst.svg").read_text(encoding="utf-8"),
     )
 

--- a/tests/test_render_landing.py
+++ b/tests/test_render_landing.py
@@ -14,10 +14,38 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tools"))
 import render_landing
 from publish_schemas import BASE
 from render_landing import (
-    RenderError, parse_workstreams, render, render_workstreams, schema_count, spec_version,
+    RenderError, parse_priority_scope, parse_workstreams, render, render_priority_scope,
+    render_workstreams, schema_count, spec_version,
 )
 
 REPO = Path(__file__).resolve().parents[1]
+
+CONTRIBUTING = """# Contributing to ACS
+
+## Current Priority Scope
+
+Reviewed at each milestone. Current window: Day 0 to Day 30.
+
+The project has one committed outcome:
+
+> A runnable Guardian Agent reference implementation, benchmarked for
+> interoperability against Microsoft Agent Governance Toolkit, in the hands
+> of external evaluators within ninety days of the September 10, 2026
+> kick-off.
+
+Every issue and every pull request is accepted against that sentence.
+
+## How work gets accepted
+
+Anyone may open an issue.
+"""
+
+CONTRIBUTING_SCOPE = (
+    "A runnable Guardian Agent reference implementation, benchmarked for "
+    "interoperability against Microsoft Agent Governance Toolkit, in the hands "
+    "of external evaluators within ninety days of the September 10, 2026 "
+    "kick-off."
+)
 
 GOVERNANCE = """# Governance
 
@@ -43,7 +71,9 @@ Not a workstream.
 
 FULL_TEMPLATE = (
     "<!--ACS:SPEC_VERSION--><!--ACS:SCHEMA_COUNT--><!--ACS:SCHEMA_HREF-->"
-    "<tbody><!--ACS:WORKSTREAMS--></tbody><div><!--ACS:STARBURST--></div>"
+    "<tbody><!--ACS:WORKSTREAMS--></tbody>"
+    "<blockquote><!--ACS:PRIORITY_SCOPE--></blockquote>"
+    "<div><!--ACS:STARBURST--></div>"
 )
 
 
@@ -167,6 +197,36 @@ def test_parse_workstreams_handles_the_real_file():
     assert len(parse_workstreams((REPO / "GOVERNANCE.md").read_text(encoding="utf-8"))) == 5
 
 
+# --- priority scope parsing ------------------------------------------------
+
+def test_parse_priority_scope_reads_the_committed_outcome():
+    assert parse_priority_scope(CONTRIBUTING) == CONTRIBUTING_SCOPE
+
+
+def test_parse_priority_scope_fails_without_the_heading():
+    with pytest.raises(RenderError, match="Current Priority Scope"):
+        parse_priority_scope("# Contributing to ACS\n\nNothing here.\n")
+
+
+def test_parse_priority_scope_fails_without_a_blockquote():
+    """A heading with prose but no committed-outcome quote must not render silently."""
+    text = CONTRIBUTING.replace(
+        "> A runnable Guardian Agent reference implementation, benchmarked for\n"
+        "> interoperability against Microsoft Agent Governance Toolkit, in the hands\n"
+        "> of external evaluators within ninety days of the September 10, 2026\n"
+        "> kick-off.\n",
+        "",
+    )
+    with pytest.raises(RenderError, match="blockquote"):
+        parse_priority_scope(text)
+
+
+def test_parse_priority_scope_handles_the_real_file():
+    scope = parse_priority_scope((REPO / "CONTRIBUTING.md").read_text(encoding="utf-8"))
+    assert scope.startswith("A runnable Guardian Agent reference implementation")
+    assert "Microsoft Agent Governance Toolkit" in scope
+
+
 # --- escaping -------------------------------------------------------------
 
 def test_render_workstreams_converts_markdown_links_to_html():
@@ -217,15 +277,27 @@ def test_render_workstreams_escapes_raw_html():
     assert "&lt;script&gt;" in html
 
 
+def test_render_priority_scope_escapes_raw_html():
+    """The blockquote is a build input like GOVERNANCE.md, reviewed for wording, not markup."""
+    scope = parse_priority_scope(CONTRIBUTING.replace(
+        "A runnable Guardian Agent reference implementation,",
+        "A runnable Guardian Agent <script>alert(1)</script> reference implementation,",
+    ))
+    out = render_priority_scope(scope)
+    assert "<script>" not in out
+    assert "&lt;script&gt;" in out
+
+
 # --- placeholders ---------------------------------------------------------
 
 def test_render_fills_every_placeholder(spec_tree):
-    out = render(FULL_TEMPLATE, spec_tree, GOVERNANCE, "<svg id='sb'/>")
+    out = render(FULL_TEMPLATE, spec_tree, GOVERNANCE, CONTRIBUTING, "<svg id='sb'/>")
     assert "v0.1.0" in out and "Identity" in out and "<svg id='sb'/>" in out
+    assert CONTRIBUTING_SCOPE in out
 
 
 def test_render_derives_the_schema_href_from_the_version(spec_tree):
-    out = render(FULL_TEMPLATE, spec_tree, GOVERNANCE, "<svg/>")
+    out = render(FULL_TEMPLATE, spec_tree, GOVERNANCE, CONTRIBUTING, "<svg/>")
     assert "schema/v0.1.0/acs_schema.json" in out
 
 
@@ -233,12 +305,12 @@ def test_render_fails_when_the_template_drops_a_placeholder(spec_tree):
     """A template missing the hero would otherwise ship a blank div with no error."""
     without = FULL_TEMPLATE.replace("<!--ACS:STARBURST-->", "")
     with pytest.raises(RenderError, match="STARBURST"):
-        render(without, spec_tree, GOVERNANCE, "<svg/>")
+        render(without, spec_tree, GOVERNANCE, CONTRIBUTING, "<svg/>")
 
 
 def test_render_fails_when_an_unknown_placeholder_survives(spec_tree):
     with pytest.raises(RenderError, match="unfilled placeholder"):
-        render(FULL_TEMPLATE + "<!--ACS:UNKNOWN-->", spec_tree, GOVERNANCE, "<svg/>")
+        render(FULL_TEMPLATE + "<!--ACS:UNKNOWN-->", spec_tree, GOVERNANCE, CONTRIBUTING, "<svg/>")
 
 
 def test_main_does_not_republish_the_inlined_diagram(tmp_path):

--- a/tools/apply_governance.py
+++ b/tools/apply_governance.py
@@ -316,6 +316,11 @@ def desired_issues() -> list[Issue]:
     without waiting on triage. The 7 follow-ups are real findings the plan surfaced
     while writing itself, but none sit on the ninety-day serial chain, so they carry
     `scope:deferred` and wait for a maintainer like anything else filed from outside.
+
+    No seeded issue carries `priority:P0`. Per GOVERNANCE.md lines 32-34, P0 is reserved
+    for work on the serial chain: PR #21 (the floor decision), PR #22 (the adapters),
+    the installable Guardian, and the interoperability benchmark. No seeded issue is one
+    of those four links. Maintainers will apply P0 to PRs #21 and #22 during triage.
     """
     onramp = ("scope:in-focus", "status:accepted", "help wanted")
     tracked = ("scope:deferred", "status:needs-triage")
@@ -324,35 +329,42 @@ def desired_issues() -> list[Issue]:
         Issue(
             title="Port the AGT reference implementation to Python",
             body=(
-                "Port the AGT reference implementation from PR #60 to Python. This is "
-                "on the serial chain to the interoperability benchmark: it is one of "
-                "the runtimes the ninety-day committed outcome names."
+                "Port the AGT reference implementation from PR #60 to Python. "
+                "Multi-language runtimes make the reference implementation more compelling "
+                "to enterprise evaluators and widen its reach across teams. This is valuable "
+                "parallel work that does not block the interoperability benchmark."
             ),
-            labels=onramp + ("workstream:coding-agents", "priority:P0"),
+            labels=onramp + ("workstream:coding-agents", "priority:P1"),
         ),
         Issue(
             title="Port the AGT reference implementation to Go",
             body=(
-                "Port the AGT reference implementation from PR #60 to Go. Same "
-                "serial-chain rationale as the Python port."
+                "Port the AGT reference implementation from PR #60 to Go. "
+                "Multi-language runtimes make the reference implementation more compelling "
+                "to enterprise evaluators and widen its reach across teams. This is valuable "
+                "parallel work that does not block the interoperability benchmark."
             ),
-            labels=onramp + ("workstream:coding-agents", "priority:P0"),
+            labels=onramp + ("workstream:coding-agents", "priority:P1"),
         ),
         Issue(
             title="Port the AGT reference implementation to Rust",
             body=(
-                "Port the AGT reference implementation from PR #60 to Rust. Same "
-                "serial-chain rationale as the Python port."
+                "Port the AGT reference implementation from PR #60 to Rust. "
+                "Multi-language runtimes make the reference implementation more compelling "
+                "to enterprise evaluators and widen its reach across teams. This is valuable "
+                "parallel work that does not block the interoperability benchmark."
             ),
-            labels=onramp + ("workstream:coding-agents", "priority:P0"),
+            labels=onramp + ("workstream:coding-agents", "priority:P1"),
         ),
         Issue(
             title="Build a reference implementation against Codex",
             body=(
                 "Build a Guardian reference implementation adapter against Codex, "
-                "alongside the Claude Code, Cursor, and NVIDIA NAT adapters in PR #22."
+                "alongside the Claude Code, Cursor, and NVIDIA NAT adapters in PR #22. "
+                "Additional adapters strengthen the reference implementation and showcase "
+                "ACS capability across platforms without blocking the benchmark."
             ),
-            labels=onramp + ("workstream:coding-agents", "priority:P0"),
+            labels=onramp + ("workstream:coding-agents", "priority:P1"),
         ),
         Issue(
             title="Add span batching to the reference implementation",

--- a/tools/apply_governance.py
+++ b/tools/apply_governance.py
@@ -663,6 +663,12 @@ def _ruleset_payload(desired: Ruleset) -> dict:
                     "required_status_checks": [
                         {"context": check} for check in desired.required_status_checks
                     ],
+                    # GitHub returns HTTP 422 with the rule index (/rules/3) rather than
+                    # a field name if these two parameters are missing. Their presence is
+                    # required even when set to false. Set both false to match the
+                    # protect-main shape this repository already runs successfully.
+                    "strict_required_status_checks_policy": False,
+                    "do_not_enforce_on_create": False,
                 },
             },
         ],

--- a/tools/apply_governance.py
+++ b/tools/apply_governance.py
@@ -1,0 +1,982 @@
+#!/usr/bin/env python3
+"""Apply the Phase 2 contribution-governance configuration to the live repository.
+
+Phase 2 of design/plans/2026-09-09-contribution-governance.md is a 14-step manual
+runbook of `gh` commands. Hand-typing it once, the night before a public relaunch, is
+how a repository ends up half-migrated: a label renamed but the milestones missed, or
+a ruleset created twice with slightly different settings the second time. This module
+turns the steps that are safe to automate into one idempotent, dry-runnable tool, so
+running it twice against the same live state is a no-op rather than a second mutation.
+
+The desired state lives in plain functions (`desired_labels`, `desired_milestones`,
+`desired_issues`, `desired_rulesets`) that take no arguments and touch no network. The
+diff between that desired state and a live-state dict is `plan_actions`, also pure.
+Only `fetch_live_state` and `run_action` touch the network, and only `main` calls them,
+so the interesting logic runs under test without a `gh` binary or a token.
+
+SAFETY PROPERTY: this tool cannot merge a pull request, close one, retarget one, or
+delete a label. Those are either human decisions (Phase 2 Steps 3, 6, 7, and 8 promote
+or merge someone else's work) or destructive (a deleted label vanishes from every issue
+that carried it). No function in this module builds a `gh` argv that merges, closes,
+or edits a pull request, or that deletes a label, and `HUMAN_STEPS` below says so out
+loud when asked for one of the steps that requires a person.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO = "GenAI-Security-Project/agent-control-standard"
+
+# The step names this tool will run. Anything else, including every step name in
+# HUMAN_STEPS, is refused rather than guessed at.
+AUTOMATABLE_STEPS = (
+    "labels",
+    "milestones",
+    "rulesets",
+    "branch",
+    "issues",
+    "default-branch",
+    "required-check",
+)
+
+# Phase 2 steps this tool deliberately does not run, and why. Keyed by the name someone
+# would reasonably type for `--only`. Each explanation names the plan step so a reader
+# can go verify the reasoning against the runbook instead of trusting this comment.
+HUMAN_STEPS = {
+    "pin-protect-main": (
+        "Phase 2 Step 1. The ruleset payload is fetched from the live API and edited "
+        "in place. A generic patch here risks overwriting a field GitHub added since "
+        "the plan was written, which is exactly why the plan describes this edit "
+        "rather than pasting a payload for it."
+    ),
+    "merge-ready-prs": (
+        "Phase 2 Step 3. Merging a pull request decides that someone else's work is "
+        "ready. That decision is not this tool's to make."
+    ),
+    "retarget-prs": (
+        "Phase 2 Step 6. Retargeting a pull request touches a contributor's open work "
+        "and needs a human to confirm the checks re-ran on the new base."
+    ),
+    "merge-phase1-pr": (
+        "Phase 2 Step 7. Merging the pull request that installs this very tool is a "
+        "human decision, same as any other merge."
+    ),
+    "promote": (
+        "Phase 2 Step 8. Promoting integration to main is a merge to the branch that "
+        "publishes the site and all 44 schema $id URIs on merge. That is a merge, and "
+        "merging is a human decision this tool will not make."
+    ),
+    "verify": (
+        "Phase 2 Step 14. Proving the guard fires means opening a real pull request "
+        "and then closing it once it has served its purpose. This tool will not close "
+        "a pull request, so run this step by hand."
+    ),
+}
+
+
+# --- Desired-state data model ------------------------------------------------
+
+@dataclass(frozen=True)
+class Label:
+    """One entry in the label taxonomy.
+
+    `rename_from` is what separates a rename from a create. A rename keeps every issue
+    already carrying the old name. A create starts the new name at zero issues. GitHub
+    seeds `bug`, `documentation`, and `enhancement` on every new repository, and this
+    project's open issues already carry them, so those three rename rather than create.
+    `description` of None means "leave the live description alone": the plan's rename
+    commands pass `--color` and `--name` but no `--description`, and a diff that treats
+    that omission as "set it to empty" would repaint a description a maintainer wrote.
+    """
+
+    name: str
+    color: str
+    description: str | None = None
+    rename_from: str | None = None
+
+
+@dataclass(frozen=True)
+class Milestone:
+    title: str
+    due_on: str
+    description: str
+
+
+@dataclass(frozen=True)
+class Issue:
+    title: str
+    body: str
+    labels: tuple[str, ...]
+    milestone: str | None = None
+
+
+@dataclass(frozen=True)
+class Ruleset:
+    """A branch ruleset, flattened out of GitHub's nested rule-array shape.
+
+    GitHub nests every setting inside `rules[].parameters` by rule type. Flattening it
+    here means the diff functions compare fields, not walk a rules array looking for
+    the one with `type == "pull_request"`. The nested shape comes back at render time,
+    in `_ruleset_payload`, which is the only place that has to know GitHub's layout.
+
+    Deletion and non-fast-forward protection are not fields because every ruleset this
+    tool renders carries both, unconditionally, so there is nothing to diff.
+    """
+
+    name: str
+    target_ref: str
+    required_status_checks: tuple[str, ...] = ("test", "build")
+    allowed_merge_methods: tuple[str, ...] = ("squash", "rebase")
+    required_approving_review_count: int = 1
+    require_code_owner_review: bool = True
+    dismiss_stale_reviews_on_push: bool = True
+    require_last_push_approval: bool = True
+    required_review_thread_resolution: bool = True
+    enforcement: str = "active"
+
+
+@dataclass(frozen=True)
+class DesiredState:
+    labels: tuple[Label, ...]
+    milestones: tuple[Milestone, ...]
+    issues: tuple[Issue, ...]
+    rulesets: tuple[Ruleset, ...]
+
+
+@dataclass(frozen=True)
+class Action:
+    """One command this tool would run, rendered but not yet executed.
+
+    `argv` never starts a shell, so there is no quoting hazard between a title or body
+    pulled from this module and a command a live title could inject into. `payload`
+    carries a JSON body for the one call that needs one (`gh api ... --input`). The
+    literal token "@@PAYLOAD@@" in argv marks where the executor substitutes a real
+    file path once it has written the payload to disk.
+    """
+
+    step: str
+    description: str
+    argv: tuple[str, ...]
+    payload: dict | None = None
+
+
+# --- Desired state ------------------------------------------------------------
+
+def desired_labels() -> list[Label]:
+    """The label taxonomy from Phase 2 Step 2: five axes, plus two stock defaults.
+
+    The five axes are `type:`, `scope:`, `status:`, `priority:`, and `workstream:`.
+    `help wanted` and `good first issue` are GitHub's own defaults. Step 2 never
+    creates them, because every repository already has them, but the nine seeded
+    onramp issues (desired_issues, below) depend on `help wanted` existing, and an
+    idempotent tool has to be able to recreate a default label a maintainer deleted
+    by accident, not assume it is still there.
+    """
+    return [
+        # Renames. Existing issues keep their labels. Only the name and color change.
+        Label(name="type:bug", color="d73a4a", rename_from="bug"),
+        Label(name="type:docs", color="0075ca", rename_from="documentation"),
+        Label(name="type:proposal", color="a2eeef", rename_from="enhancement"),
+        # Creates.
+        Label(
+            name="type:refimpl", color="1d76db",
+            description="Reference implementation or adapter work",
+        ),
+        Label(
+            name="type:conformance", color="5319e7",
+            description="Conformance or dogfooding report",
+        ),
+        Label(
+            name="scope:in-focus", color="0e8a16",
+            description="Feeds the ninety-day committed outcome. Maintainers only",
+        ),
+        Label(
+            name="scope:deferred", color="fbca04",
+            description="Real work, tracked, lands after Day 90. Maintainers only",
+        ),
+        Label(
+            name="scope:out", color="e4e669",
+            description="Outside what ACS does by design. Maintainers only",
+        ),
+        Label(
+            name="status:needs-triage", color="ededed",
+            description="Not yet triaged. Applied by the issue forms",
+        ),
+        Label(
+            name="status:accepted", color="0e8a16",
+            description="In the backlog. Maintainers only",
+        ),
+        Label(
+            name="status:blocked", color="b60205",
+            description="Waiting on another decision or PR",
+        ),
+        Label(
+            name="status:needs-info", color="d876e3",
+            description="Waiting on the filer",
+        ),
+        Label(
+            name="priority:P0", color="b60205",
+            description="On the serial chain to the benchmark. Maintainers only",
+        ),
+        Label(name="priority:P1", color="d93f0b", description="Maintainers only"),
+        Label(name="priority:P2", color="fef2c0", description="Maintainers only"),
+        Label(
+            name="workstream:spec", color="c5def5",
+            description="Owning workstream. Maintainers only",
+        ),
+        Label(
+            name="workstream:coding-agents", color="c5def5",
+            description="Owning workstream. Maintainers only",
+        ),
+        Label(
+            name="workstream:sdk", color="c5def5",
+            description="Owning workstream. Maintainers only",
+        ),
+        Label(
+            name="workstream:identity", color="c5def5",
+            description="Owning workstream. Maintainers only",
+        ),
+        Label(
+            name="workstream:outreach", color="c5def5",
+            description="Owning workstream. Maintainers only",
+        ),
+        # Stock GitHub defaults. Not created by Step 2, but relied on by Step 12.
+        Label(
+            name="help wanted", color="008672",
+            description="Already accepted work. Safe to start without waiting on triage.",
+        ),
+        Label(name="good first issue", color="7057ff", description="Good for newcomers"),
+    ]
+
+
+def desired_milestones() -> list[Milestone]:
+    """The four milestones from Phase 2 Step 11, dates and descriptions verbatim."""
+    return [
+        Milestone(
+            title="Day 14",
+            due_on="2026-09-24",
+            description=(
+                "Reference Implementation lead named. PR #21 floor decision closed. "
+                "Discussions seeded. Domain transfer counterpart identified."
+            ),
+        ),
+        Milestone(
+            title="Day 30",
+            due_on="2026-10-09",
+            description=(
+                "PR #22 merged with the emission-conformance suite in CI. Documentation "
+                "and Testing lead seats filled. Conformance claim template published. "
+                "Fail-open resolution decided."
+            ),
+        ),
+        Milestone(
+            title="Day 60",
+            due_on="2026-11-06",
+            description=(
+                "Installable reference Guardian published. Milestone #33 requirement "
+                "ledger drafted. AARM mapping session held. Domains transferred. "
+                "OpenSSF registered."
+            ),
+        ),
+        Milestone(
+            title="Day 90",
+            due_on="2026-12-04",
+            description=(
+                "AGT interoperability benchmark published with results and "
+                "disagreements. Cursor file-read gap closed. One external ACS-Core "
+                "compatibility claim."
+            ),
+        ),
+    ]
+
+
+def desired_issues() -> list[Issue]:
+    """The 9 seeded onramp issues and 7 tracked follow-ups from Steps 12 and 13.
+
+    Every seeded issue carries `scope:in-focus`, `status:accepted`, and `help wanted`.
+    Those three labels are what make the acceptance gate CONTRIBUTING.md describes an
+    invitation rather than a queue: a contributor can open a pull request against one
+    without waiting on triage. The 7 follow-ups are real findings the plan surfaced
+    while writing itself, but none sit on the ninety-day serial chain, so they carry
+    `scope:deferred` and wait for a maintainer like anything else filed from outside.
+    """
+    onramp = ("scope:in-focus", "status:accepted", "help wanted")
+    tracked = ("scope:deferred", "status:needs-triage")
+
+    seeded = [
+        Issue(
+            title="Port the AGT reference implementation to Python",
+            body=(
+                "Port the AGT reference implementation from PR #60 to Python. This is "
+                "on the serial chain to the interoperability benchmark: it is one of "
+                "the runtimes the ninety-day committed outcome names."
+            ),
+            labels=onramp + ("workstream:coding-agents", "priority:P0"),
+        ),
+        Issue(
+            title="Port the AGT reference implementation to Go",
+            body=(
+                "Port the AGT reference implementation from PR #60 to Go. Same "
+                "serial-chain rationale as the Python port."
+            ),
+            labels=onramp + ("workstream:coding-agents", "priority:P0"),
+        ),
+        Issue(
+            title="Port the AGT reference implementation to Rust",
+            body=(
+                "Port the AGT reference implementation from PR #60 to Rust. Same "
+                "serial-chain rationale as the Python port."
+            ),
+            labels=onramp + ("workstream:coding-agents", "priority:P0"),
+        ),
+        Issue(
+            title="Build a reference implementation against Codex",
+            body=(
+                "Build a Guardian reference implementation adapter against Codex, "
+                "alongside the Claude Code, Cursor, and NVIDIA NAT adapters in PR #22."
+            ),
+            labels=onramp + ("workstream:coding-agents", "priority:P0"),
+        ),
+        Issue(
+            title="Add span batching to the reference implementation",
+            body=(
+                "Production-harden the reference implementation with span batching. "
+                "Current Priority Scope in CONTRIBUTING.md lists this hardening work "
+                "as in focus."
+            ),
+            labels=onramp + ("workstream:coding-agents", "priority:P1"),
+        ),
+        Issue(
+            title=(
+                "Configure OpenTelemetry collection and export in the reference "
+                "implementation"
+            ),
+            body=(
+                "Production-harden the reference implementation by wiring "
+                "OpenTelemetry collection and export end to end."
+            ),
+            labels=onramp + ("workstream:coding-agents", "priority:P1"),
+        ),
+        Issue(
+            title="Dogfood AGT with ACS and file a conformance report",
+            body=(
+                "Run the Microsoft Agent Governance Toolkit against an ACS Guardian "
+                "and file a conformance report for every place behavior and "
+                "specification disagree. Conformance evidence is what makes the "
+                "benchmark credible."
+            ),
+            labels=onramp + ("workstream:coding-agents", "priority:P1"),
+        ),
+        Issue(
+            title="Publish the one-page ACS-Core conformance claim template",
+            body=(
+                "Draft and publish the one-page template an implementer fills out to "
+                "make an ACS-Core conformance claim. Open decision, Day 30 date."
+            ),
+            labels=onramp + ("workstream:spec", "priority:P1"),
+            milestone="Day 30",
+        ),
+        Issue(
+            title=(
+                "Choose and reserve a distribution name for the reference "
+                "implementation"
+            ),
+            body=(
+                "Choose a package or distribution name for the reference "
+                "implementation and reserve it before the first release. Open "
+                "decision, Day 30 date."
+            ),
+            labels=onramp + ("workstream:coding-agents", "priority:P1"),
+            milestone="Day 30",
+        ),
+    ]
+
+    followups = [
+        Issue(
+            title=(
+                "Workstream vocabulary mismatch between GOVERNANCE.md and the plan's "
+                "open lead seats"
+            ),
+            body=(
+                "GOVERNANCE.md names five workstreams: Spec, Coding Agents, "
+                "Development (SDK), Identity, and Outreach. The Strategic Adoption "
+                "Plan's open lead seats use different names for some of the same "
+                "work. Reconcile the two vocabularies."
+            ),
+            labels=("type:docs",) + tracked,
+        ),
+        Issue(
+            title="Label-strip enforcement workflow, if the permission lookup proves workable",
+            body=(
+                "Investigate whether a workflow can reliably strip a decision label "
+                "added by someone without triage authority. Tracked rather than "
+                "built now because the permission lookup it depends on is unproven."
+            ),
+            labels=("type:proposal",) + tracked,
+        ),
+        Issue(
+            title="Org-level project board fed by this label and milestone taxonomy",
+            body=(
+                "Build an org-level GitHub Project fed by the label and milestone "
+                "taxonomy this plan installs. Needs org admin access, which this tool "
+                "does not have and should not be given."
+            ),
+            labels=("type:proposal",) + tracked,
+        ),
+        Issue(
+            title="Declarative logic CI for specification contradiction detection",
+            body=(
+                "Explore a CI check that detects logical contradictions across the "
+                "specification's normative statements, rather than relying on review "
+                "to catch them."
+            ),
+            labels=("type:proposal",) + tracked,
+        ),
+        Issue(
+            title=(
+                "Release-branch versioning, unspecified now that sync_version.yml "
+                "follows integration"
+            ),
+            body=(
+                "sync_version.yml now targets `integration` instead of `main`. "
+                "Decide how version bumps work on a `release/*` branch, which that "
+                "change left unspecified."
+            ),
+            labels=("type:proposal",) + tracked,
+        ),
+        Issue(
+            title="Comment on #52 that the DCO check stays indifferent to non-sign-off trailers",
+            body=(
+                "Post a comment on #52 noting that the DCO check does not care "
+                "whether a commit carries a `Co-Authored-By` trailer or any trailer "
+                "beyond `Signed-off-by`. Filed here so the follow-up is not lost."
+            ),
+            labels=("type:docs",) + tracked,
+        ),
+        Issue(
+            title=(
+                "Confirm whether Dependabot security updates honor a non-default "
+                "target-branch"
+            ),
+            body=(
+                "Dependabot's routine updates follow the default branch by design. "
+                "Confirm whether security updates do the same or bypass "
+                "target-branch, since that behavior is undocumented and Task 7 "
+                "depends on it not mattering."
+            ),
+            labels=("type:proposal",) + tracked,
+        ),
+    ]
+
+    return seeded + followups
+
+
+def desired_rulesets() -> list[Ruleset]:
+    """protect-integration and protect-release, from Phase 2 Step 5.
+
+    Both mirror the pre-change protect-main: one approval, code owner review, stale
+    reviews dismissed on push, last-push approval, required thread resolution, the
+    `test` and `build` checks, and squash or rebase merges only. Every field left at
+    its default on Ruleset already carries that shape, so the two instances below
+    differ only in the two fields Step 5 says differ: the name and the target ref.
+    """
+    return [
+        Ruleset(name="protect-integration", target_ref="refs/heads/integration"),
+        Ruleset(name="protect-release", target_ref="refs/heads/release/*"),
+    ]
+
+
+def desired_state() -> DesiredState:
+    return DesiredState(
+        labels=tuple(desired_labels()),
+        milestones=tuple(desired_milestones()),
+        issues=tuple(desired_issues()),
+        rulesets=tuple(desired_rulesets()),
+    )
+
+
+# --- Diffing: desired vs. live, pure -----------------------------------------
+
+def _label_matches(live: dict, desired: Label) -> bool:
+    if live.get("name") != desired.name or live.get("color") != desired.color:
+        return False
+    # None means "the plan's command never set a description", so a live description
+    # of anything is a match. Comparing against "" would repaint every rename target.
+    if desired.description is not None and live.get("description", "") != desired.description:
+        return False
+    return True
+
+
+def plan_label_actions(live_labels: list[dict], desired: tuple[Label, ...]) -> list[Action]:
+    """Diff Phase 2 Step 2 against a live `gh label list --json name,color,description`."""
+    by_name = {entry["name"]: entry for entry in live_labels}
+    actions: list[Action] = []
+    for label in desired:
+        current = by_name.get(label.name)
+        if current is not None and _label_matches(current, label):
+            continue
+        if label.rename_from and label.rename_from in by_name:
+            argv = ["gh", "label", "edit", label.rename_from, "--name", label.name, "--color", label.color]
+            if label.description is not None:
+                argv += ["--description", label.description]
+            actions.append(Action("labels", f"Rename {label.rename_from!r} to {label.name!r}", tuple(argv)))
+        else:
+            argv = ["gh", "label", "create", label.name, "--force", "--color", label.color]
+            if label.description is not None:
+                argv += ["--description", label.description]
+            actions.append(Action("labels", f"Create label {label.name!r}", tuple(argv)))
+    return actions
+
+
+def _milestone_matches(live: dict, desired: Milestone) -> bool:
+    return live.get("due_on") == desired.due_on and live.get("description") == desired.description
+
+
+def plan_milestone_actions(
+    live_milestones: list[dict], desired: tuple[Milestone, ...]
+) -> list[Action]:
+    """Diff Phase 2 Step 11 against a live milestone listing keyed by title."""
+    by_title = {entry["title"]: entry for entry in live_milestones}
+    actions: list[Action] = []
+    for milestone in desired:
+        current = by_title.get(milestone.title)
+        if current is not None and _milestone_matches(current, milestone):
+            continue
+        due = f"{milestone.due_on}T23:59:59Z"
+        if current is None:
+            argv = (
+                "gh", "api", "-X", "POST", f"repos/{REPO}/milestones",
+                "-f", f"title={milestone.title}",
+                "-f", f"due_on={due}",
+                "-f", f"description={milestone.description}",
+            )
+            description = f"Create milestone {milestone.title!r}"
+        else:
+            number = current.get("number")
+            argv = (
+                "gh", "api", "-X", "PATCH", f"repos/{REPO}/milestones/{number}",
+                "-f", f"due_on={due}",
+                "-f", f"description={milestone.description}",
+            )
+            description = f"Update milestone {milestone.title!r}"
+        actions.append(Action("milestones", description, argv))
+    return actions
+
+
+def plan_issue_actions(live_issues: list[dict], desired: tuple[Issue, ...]) -> list[Action]:
+    """Diff Phase 2 Steps 12 and 13. Matched by title, filed once, never edited or closed.
+
+    The plan never revises a seeded issue after filing it, and this tool has no way to
+    tell a maintainer's later edit from drift it should undo, so an existing title with
+    the same text is left alone rather than reconciled label by label.
+    """
+    filed = {entry["title"] for entry in live_issues}
+    actions: list[Action] = []
+    for issue in desired:
+        if issue.title in filed:
+            continue
+        argv = ["gh", "issue", "create", "--title", issue.title, "--body", issue.body]
+        for label in issue.labels:
+            argv += ["--label", label]
+        if issue.milestone:
+            argv += ["--milestone", issue.milestone]
+        actions.append(Action("issues", f"File issue {issue.title!r}", tuple(argv)))
+    return actions
+
+
+def _ruleset_matches(live: dict, desired: Ruleset) -> bool:
+    return (
+        live.get("target_ref") == desired.target_ref
+        and live.get("enforcement", "active") == desired.enforcement
+        and live.get("required_approving_review_count") == desired.required_approving_review_count
+        and live.get("require_code_owner_review") == desired.require_code_owner_review
+        and live.get("dismiss_stale_reviews_on_push") == desired.dismiss_stale_reviews_on_push
+        and live.get("require_last_push_approval") == desired.require_last_push_approval
+        and live.get("required_review_thread_resolution") == desired.required_review_thread_resolution
+        and tuple(live.get("required_status_checks", ())) == desired.required_status_checks
+        and tuple(live.get("allowed_merge_methods", ())) == desired.allowed_merge_methods
+    )
+
+
+def _ruleset_payload(desired: Ruleset) -> dict:
+    """Rebuild GitHub's nested rules array from a flat Ruleset.
+
+    Deletion and non-fast-forward protection are unconditional, per the plan's Step 5,
+    so they are written here rather than carried as fields with only one valid value.
+    """
+    return {
+        "name": desired.name,
+        "target": "branch",
+        "enforcement": desired.enforcement,
+        "conditions": {"ref_name": {"include": [desired.target_ref], "exclude": []}},
+        "rules": [
+            {"type": "deletion"},
+            {"type": "non_fast_forward"},
+            {
+                "type": "pull_request",
+                "parameters": {
+                    "required_approving_review_count": desired.required_approving_review_count,
+                    "require_code_owner_review": desired.require_code_owner_review,
+                    "dismiss_stale_reviews_on_push": desired.dismiss_stale_reviews_on_push,
+                    "require_last_push_approval": desired.require_last_push_approval,
+                    "required_review_thread_resolution": desired.required_review_thread_resolution,
+                    "allowed_merge_methods": list(desired.allowed_merge_methods),
+                },
+            },
+            {
+                "type": "required_status_checks",
+                "parameters": {
+                    "required_status_checks": [
+                        {"context": check} for check in desired.required_status_checks
+                    ],
+                },
+            },
+        ],
+    }
+
+
+def plan_ruleset_actions(live_rulesets: list[dict], desired: tuple[Ruleset, ...]) -> list[Action]:
+    """Diff Phase 2 Step 5. Never touches protect-main. See plan_required_check_actions."""
+    by_name = {entry["name"]: entry for entry in live_rulesets}
+    actions: list[Action] = []
+    for ruleset in desired:
+        current = by_name.get(ruleset.name)
+        if current is not None and _ruleset_matches(current, ruleset):
+            continue
+        if current is None:
+            argv = ("gh", "api", "-X", "POST", f"repos/{REPO}/rulesets", "--input", "@@PAYLOAD@@")
+            description = f"Create ruleset {ruleset.name!r}"
+        else:
+            ruleset_id = current.get("id")
+            argv = (
+                "gh", "api", "-X", "PUT", f"repos/{REPO}/rulesets/{ruleset_id}",
+                "--input", "@@PAYLOAD@@",
+            )
+            description = f"Update ruleset {ruleset.name!r}"
+        actions.append(Action("rulesets", description, argv, payload=_ruleset_payload(ruleset)))
+    return actions
+
+
+def plan_actions(live_state: dict, desired_state: DesiredState) -> list[Action]:
+    """Diff desired against live for labels, milestones, issues, and rulesets.
+
+    Pure: no network call, no side effect. Calling this twice with the live state the
+    first call would have produced returns an empty list the second time, which is
+    what makes the tool idempotent rather than merely repeatable.
+    """
+    return [
+        *plan_label_actions(live_state.get("labels", []), desired_state.labels),
+        *plan_milestone_actions(live_state.get("milestones", []), desired_state.milestones),
+        *plan_issue_actions(live_state.get("issues", []), desired_state.issues),
+        *plan_ruleset_actions(live_state.get("rulesets", []), desired_state.rulesets),
+    ]
+
+
+def plan_branch_actions(live_state: dict) -> list[Action]:
+    """Phase 2 Step 4: create `integration` from `main` if it does not exist yet.
+
+    A branch cannot be half-created, so there is exactly one action or none. This
+    pushes a branch ref rather than opening a pull request, because at this point in
+    the runbook `integration` does not exist for a pull request to target.
+    """
+    if "integration" in set(live_state.get("branches", ())):
+        return []
+    return [
+        Action(
+            "branch",
+            "Create integration from main",
+            ("git", "push", "origin", "origin/main:refs/heads/integration"),
+        )
+    ]
+
+
+def plan_default_branch_actions(live_state: dict) -> list[Action]:
+    """Phase 2 Step 9: move the default branch to `integration`.
+
+    The plan requires protect-main to be pinned to the literal ref `refs/heads/main`
+    first (Step 1), or the move leaves `main` unprotected once it is no longer the
+    default. That precondition is not observable from live_state as fetched here, so
+    this function does not check it. The human running Step 1 is the check.
+    """
+    if live_state.get("default_branch") == "integration":
+        return []
+    return [
+        Action(
+            "default-branch",
+            "Move the default branch to integration",
+            ("gh", "repo", "edit", REPO, "--default-branch", "integration"),
+        )
+    ]
+
+
+def plan_required_check_actions(live_state: dict) -> list[Action]:
+    """Phase 2 Step 10: add base-branch-guard to protect-main's required checks.
+
+    Only the check list changes. Every other protect-main field is read back from
+    live_state and written unchanged, because this step runs against a ruleset a
+    human already configured in Step 1 and this tool must not relitigate the rest of
+    it while adding one check.
+    """
+    protect_main = live_state.get("protect_main")
+    if protect_main is None:
+        # No live ruleset to patch. The caller fetched nothing, so there is nothing
+        # to diff, not an inferred "it must already be fine".
+        return []
+    checks = tuple(protect_main.get("required_status_checks", ()))
+    if "base-branch-guard" in checks:
+        return []
+    updated = dict(protect_main)
+    updated["required_status_checks"] = checks + ("base-branch-guard",)
+    ruleset_id = protect_main.get("id")
+    return [
+        Action(
+            "required-check",
+            "Add base-branch-guard to protect-main's required checks",
+            ("gh", "api", "-X", "PUT", f"repos/{REPO}/rulesets/{ruleset_id}", "--input", "@@PAYLOAD@@"),
+            payload=_protect_main_payload(updated),
+        )
+    ]
+
+
+def _protect_main_payload(protect_main: dict) -> dict:
+    """Render protect-main's flat live shape back into GitHub's nested rules array."""
+    return {
+        "name": "protect-main",
+        "target": "branch",
+        "enforcement": protect_main.get("enforcement", "active"),
+        "conditions": {"ref_name": {"include": ["refs/heads/main"], "exclude": []}},
+        "rules": [
+            {"type": "deletion"},
+            {"type": "non_fast_forward"},
+            {
+                "type": "pull_request",
+                "parameters": {
+                    "required_approving_review_count": protect_main.get(
+                        "required_approving_review_count", 1
+                    ),
+                    "allowed_merge_methods": list(
+                        protect_main.get("allowed_merge_methods", ("squash", "rebase", "merge"))
+                    ),
+                },
+            },
+            {
+                "type": "required_status_checks",
+                "parameters": {
+                    "required_status_checks": [
+                        {"context": check}
+                        for check in protect_main.get("required_status_checks", ())
+                    ],
+                },
+            },
+        ],
+    }
+
+
+def collect_actions(live_state: dict, only: str | None = None) -> list[Action]:
+    """Combine every planner, filtered to one step when `only` names one."""
+    steps: list[Action] = []
+    if only in (None, "labels"):
+        steps += plan_label_actions(live_state.get("labels", []), tuple(desired_labels()))
+    if only in (None, "milestones"):
+        steps += plan_milestone_actions(live_state.get("milestones", []), tuple(desired_milestones()))
+    if only in (None, "rulesets"):
+        steps += plan_ruleset_actions(live_state.get("rulesets", []), tuple(desired_rulesets()))
+    if only in (None, "issues"):
+        steps += plan_issue_actions(live_state.get("issues", []), tuple(desired_issues()))
+    if only in (None, "branch"):
+        steps += plan_branch_actions(live_state)
+    if only in (None, "default-branch"):
+        steps += plan_default_branch_actions(live_state)
+    if only in (None, "required-check"):
+        steps += plan_required_check_actions(live_state)
+    return steps
+
+
+# --- Executor: render or run --------------------------------------------------
+
+def render_dry_run(action: Action) -> str:
+    command = " ".join(shlex.quote(token) for token in action.argv)
+    lines = [f"# {action.description}", f"$ {command}"]
+    if action.payload is not None:
+        lines.append(json.dumps(action.payload, indent=2))
+    return "\n".join(lines)
+
+
+def run_action(action: Action) -> None:
+    """Execute one action for real. Never called by a test in this repository.
+
+    A payload is written to a temp file rather than piped, so the argv `gh` actually
+    receives is identical to the one a dry run printed, minus the placeholder swap.
+    """
+    argv = list(action.argv)
+    if action.payload is None:
+        subprocess.run(argv, check=True)
+        return
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as handle:
+        json.dump(action.payload, handle)
+        payload_path = handle.name
+    try:
+        argv = [payload_path if token == "@@PAYLOAD@@" else token for token in argv]
+        subprocess.run(argv, check=True)
+    finally:
+        Path(payload_path).unlink(missing_ok=True)
+
+
+def _gh(*args: str) -> str:
+    return subprocess.run(["gh", *args], check=True, capture_output=True, text=True).stdout
+
+
+def _normalize_ruleset(detail: dict) -> dict:
+    """Flatten one `gh api repos/{repo}/rulesets/{id}` response for the diff functions."""
+    by_type = {rule["type"]: rule.get("parameters", {}) for rule in detail.get("rules", [])}
+    pr_params = by_type.get("pull_request", {})
+    checks = by_type.get("required_status_checks", {}).get("required_status_checks", [])
+    refs = detail.get("conditions", {}).get("ref_name", {}).get("include", [])
+    return {
+        "id": detail.get("id"),
+        "name": detail.get("name"),
+        "target_ref": refs[0] if refs else "",
+        "enforcement": detail.get("enforcement", "active"),
+        "required_status_checks": tuple(check["context"] for check in checks),
+        "allowed_merge_methods": tuple(pr_params.get("allowed_merge_methods", ())),
+        "required_approving_review_count": pr_params.get("required_approving_review_count"),
+        "require_code_owner_review": pr_params.get("require_code_owner_review"),
+        "dismiss_stale_reviews_on_push": pr_params.get("dismiss_stale_reviews_on_push"),
+        "require_last_push_approval": pr_params.get("require_last_push_approval"),
+        "required_review_thread_resolution": pr_params.get("required_review_thread_resolution"),
+    }
+
+
+def fetch_live_state() -> dict:
+    """Read the current repository state through `gh`. The only function that does.
+
+    Every diff function above takes a plain dict so it can be tested without this
+    function ever running. Nothing in this module calls it except `main`, and `main`
+    never reaches it on `--help`, an unknown `--only`, or a step in HUMAN_STEPS.
+    """
+    labels = json.loads(_gh("label", "list", "--limit", "200", "--json", "name,color,description"))
+
+    raw_milestones = json.loads(_gh("api", f"repos/{REPO}/milestones", "--paginate"))
+    milestones = [
+        {
+            "title": entry["title"],
+            "number": entry["number"],
+            "due_on": (entry.get("due_on") or "")[:10],
+            "description": entry.get("description") or "",
+        }
+        for entry in raw_milestones
+    ]
+
+    raw_issues = json.loads(
+        _gh("issue", "list", "--state", "all", "--limit", "500", "--json", "title,body,labels")
+    )
+    issues = [
+        {"title": entry["title"], "body": entry.get("body") or "",
+         "labels": [label["name"] for label in entry["labels"]]}
+        for entry in raw_issues
+    ]
+
+    summaries = json.loads(_gh("api", f"repos/{REPO}/rulesets"))
+    details = {
+        entry["name"]: _normalize_ruleset(json.loads(_gh("api", f"repos/{REPO}/rulesets/{entry['id']}")))
+        for entry in summaries
+    }
+    rulesets = [
+        details[name] for name in ("protect-integration", "protect-release") if name in details
+    ]
+
+    branches = json.loads(_gh("api", f"repos/{REPO}/branches", "--paginate", "--jq", "[.[].name]"))
+    repo_info = json.loads(_gh("api", f"repos/{REPO}"))
+
+    return {
+        "labels": labels,
+        "milestones": milestones,
+        "issues": issues,
+        "rulesets": rulesets,
+        "branches": branches,
+        "default_branch": repo_info.get("default_branch"),
+        "protect_main": details.get("protect-main"),
+    }
+
+
+# --- CLI ----------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="apply_governance.py",
+        description=(
+            "Apply Phase 2 of the contribution-governance plan: labels, milestones, "
+            "issues, and the integration and release rulesets. Prints the gh and git "
+            "commands it would run by default. Pass --apply to run them."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the commands without running them. This already happens without "
+             "the flag. It exists so a caller can pass it explicitly.",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Run the commands instead of printing them. Required to mutate anything.",
+    )
+    parser.add_argument(
+        "--only",
+        metavar="STEP",
+        help=f"Run a single step. One of: {', '.join(AUTOMATABLE_STEPS)}.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.only in HUMAN_STEPS:
+        print(
+            f"'{args.only}' is a human decision, not something this tool automates.\n"
+            f"{HUMAN_STEPS[args.only]}",
+            file=sys.stderr,
+        )
+        return 2
+    if args.only is not None and args.only not in AUTOMATABLE_STEPS:
+        print(
+            f"Unknown step {args.only!r}. Choose one of: {', '.join(AUTOMATABLE_STEPS)}.",
+            file=sys.stderr,
+        )
+        return 2
+
+    # --dry-run is the default behavior. --apply is the only flag that turns on
+    # mutation, so passing both is a no-op rather than a contradiction.
+    apply_changes = args.apply
+
+    live_state = fetch_live_state()
+    actions = collect_actions(live_state, only=args.only)
+
+    if not actions:
+        print("Nothing to do. Live state already matches desired state.")
+        return 0
+
+    if not apply_changes:
+        print(f"Dry run. {len(actions)} action(s) would run. Pass --apply to run them.\n")
+        for action in actions:
+            print(render_dry_run(action))
+            print()
+        return 0
+
+    for action in actions:
+        print(f"Running: {action.description}")
+        run_action(action)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/apply_governance.py
+++ b/tools/apply_governance.py
@@ -29,7 +29,7 @@ import shlex
 import subprocess
 import sys
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 REPO = "GenAI-Security-Project/agent-control-standard"
@@ -117,6 +117,11 @@ class Issue:
     milestone: str | None = None
 
 
+def _default_bypass_actors() -> tuple[dict, ...]:
+    """Admin RepositoryRole always bypass, matching protect-main's existing bypass."""
+    return ({"actor_id": 5, "actor_type": "RepositoryRole", "bypass_mode": "always"},)
+
+
 @dataclass(frozen=True)
 class Ruleset:
     """A branch ruleset, flattened out of GitHub's nested rule-array shape.
@@ -128,6 +133,10 @@ class Ruleset:
 
     Deletion and non-fast-forward protection are not fields because every ruleset this
     tool renders carries both, unconditionally, so there is nothing to diff.
+
+    bypass_actors defaults to admin always-bypass, matching protect-main. Every ruleset
+    needs this so a sole maintainer can merge into a branch requiring review, since
+    GitHub does not let anyone approve their own pull request.
     """
 
     name: str
@@ -140,6 +149,7 @@ class Ruleset:
     require_last_push_approval: bool = True
     required_review_thread_resolution: bool = True
     enforcement: str = "active"
+    bypass_actors: tuple[dict, ...] = field(default_factory=_default_bypass_actors)
 
 
 @dataclass(frozen=True)
@@ -483,7 +493,10 @@ def desired_rulesets() -> list[Ruleset]:
 
     Both mirror the pre-change protect-main: one approval, code owner review, stale
     reviews dismissed on push, last-push approval, required thread resolution, the
-    `test` and `build` checks, and squash or rebase merges only. Every field left at
+    `test` and `build` checks, and squash or rebase merges only. Both also inherit
+    the admin always-bypass from the Ruleset default, matching protect-main. Without
+    this bypass, a sole maintainer cannot merge into a branch requiring review, since
+    GitHub does not let anyone approve their own pull request. Every field left at
     its default on Ruleset already carries that shape, so the two instances below
     differ only in the two fields Step 5 says differ: the name and the target ref.
     """
@@ -610,12 +623,14 @@ def _ruleset_payload(desired: Ruleset) -> dict:
 
     Deletion and non-fast-forward protection are unconditional, per the plan's Step 5,
     so they are written here rather than carried as fields with only one valid value.
+    bypass_actors is rendered at the top level so GitHub recognizes the admin bypass.
     """
     return {
         "name": desired.name,
         "target": "branch",
         "enforcement": desired.enforcement,
         "conditions": {"ref_name": {"include": [desired.target_ref], "exclude": []}},
+        "bypass_actors": list(desired.bypass_actors),
         "rules": [
             {"type": "deletion"},
             {"type": "non_fast_forward"},

--- a/tools/base_branch_guard.py
+++ b/tools/base_branch_guard.py
@@ -1,0 +1,124 @@
+"""Keep specification and code changes off the publishing branch.
+
+`main` publishes the site and all 44 schema $id URIs on every merge. A change to
+normative content lands on `integration` first, so those URIs move only on a deliberate
+promotion. GitHub rulesets cannot express "the paths in the diff decide the base
+branch", so this does.
+
+The allowlist is positive. Anything it does not name requires `integration`, which makes
+a directory nobody anticipated a failure rather than a silent pass.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from collections.abc import Iterable
+
+PUBLISHING_BRANCH = "main"
+
+# Directory prefixes that may target the publishing branch. The trailing slash is load
+# bearing: without it, a prefix test reads docs/specimen.md as a match for docs/spec.
+DOCS_LANE_DIRECTORIES = (
+    "docs/topics/",
+    "design/",
+)
+
+# Exact files that may target the publishing branch.
+#
+# mkdocs.yml, overrides/, landing/, docs/stylesheets/, and docs/assets/ are deliberately
+# absent even though a reader would call all five documentation. CODEOWNERS treats them
+# as privilege-escalation surfaces and says why: mkdocs.yml accepts a hooks: key that
+# executes Python inside the build job, overrides holds templates the build renders into
+# every page, and a stylesheet or asset reaches a third party through url(), @font-face,
+# or @import with no script at all. A lane that deploys on merge is the wrong lane for
+# any of them.
+DOCS_LANE_FILES = frozenset({
+    "docs/README.md",
+    "README.md",
+    "CONTRIBUTORS.md",
+    "CODE_OF_CONDUCT.md",
+    "CONTRIBUTING.md",
+    "GOVERNANCE.md",
+    "SECURITY.md",
+    "STYLE.md",
+    "LICENSING.md",
+    "NOTICE",
+})
+
+# Branches a promotion pull request comes from. These carry specification paths by
+# definition.
+PROMOTION_HEADS = frozenset({"integration"})
+PROMOTION_HEAD_PREFIXES = ("release/",)
+
+
+def in_docs_lane(path: str) -> bool:
+    """True when a path may target the publishing branch directly."""
+    if path in DOCS_LANE_FILES:
+        return True
+    return path.startswith(DOCS_LANE_DIRECTORIES)
+
+
+def is_promotion(head_ref: str, head_repo: str, base_repo: str) -> bool:
+    """True when this is a promotion from a branch inside this repository.
+
+    The repository test is not optional and runs first. A pull request's head ref is a
+    branch name the contributor chose, and a fork may name a branch anything, so
+    exempting on the ref alone would let somebody fork, create a branch called
+    `integration`, and walk a specification change onto the publishing branch.
+    """
+    if head_repo != base_repo:
+        return False
+    return head_ref in PROMOTION_HEADS or head_ref.startswith(PROMOTION_HEAD_PREFIXES)
+
+
+def paths_requiring_integration(paths: Iterable[str]) -> list[str]:
+    """Return every changed path that may not target the publishing branch."""
+    return sorted({path for path in paths if not in_docs_lane(path)})
+
+
+def decide(
+    paths: Iterable[str],
+    base_ref: str,
+    head_ref: str,
+    head_repo: str,
+    base_repo: str,
+) -> tuple[int, str]:
+    """Return an exit status and the message to print."""
+    if base_ref != PUBLISHING_BRANCH:
+        return 0, f"Base branch is {base_ref!r}, not {PUBLISHING_BRANCH!r}. Nothing to check."
+    if is_promotion(head_ref, head_repo, base_repo):
+        return 0, f"Promotion from {head_ref!r}. Specification paths are expected here."
+    offenders = paths_requiring_integration(paths)
+    if not offenders:
+        return 0, "Every changed path is in the documentation lane."
+    listing = "\n".join(f"  {path}" for path in offenders)
+    return 1, (
+        f"These paths may not target `{PUBLISHING_BRANCH}`. Retarget this pull request "
+        f"at `integration`:\n{listing}\n\n"
+        f"`{PUBLISHING_BRANCH}` publishes the site and all 44 schema $id URIs on merge, "
+        "so specification and code changes land on `integration` and publish on a "
+        "promotion. See CONTRIBUTING.md."
+    )
+
+
+def main(argv: list[str]) -> int:
+    """Read the changed paths from a file and the refs from the environment."""
+    if len(argv) != 2:
+        print("usage: base_branch_guard.py <file-listing-changed-paths>", file=sys.stderr)
+        return 2
+    with open(argv[1], encoding="utf-8") as handle:
+        paths = [line.strip() for line in handle if line.strip()]
+    status, message = decide(
+        paths,
+        os.environ.get("BASE_REF", ""),
+        os.environ.get("HEAD_REF", ""),
+        os.environ.get("HEAD_REPO", ""),
+        os.environ.get("BASE_REPO", ""),
+    )
+    print(message, file=sys.stderr if status else sys.stdout)
+    return status
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tools/render_landing.py
+++ b/tools/render_landing.py
@@ -20,6 +20,7 @@ from publish_schemas import SchemaError, load_schemas, target_for
 
 # Tolerant of case and spacing so a formatter cannot break the build.
 WORKSTREAM_HEADING = re.compile(r"^##\s+workstream\s+leads\s*$", re.IGNORECASE)
+PRIORITY_SCOPE_HEADING = re.compile(r"^##\s+current\s+priority\s+scope\s*$", re.IGNORECASE)
 ANY_HEADING = re.compile(r"^#{2,6}\s")
 MD_LINK = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 PLACEHOLDER = re.compile(r"<!--ACS:[A-Z_]+-->")
@@ -31,6 +32,7 @@ REQUIRED_PLACEHOLDERS = (
     "<!--ACS:SCHEMA_COUNT-->",
     "<!--ACS:SCHEMA_HREF-->",
     "<!--ACS:WORKSTREAMS-->",
+    "<!--ACS:PRIORITY_SCOPE-->",
     "<!--ACS:STARBURST-->",
 )
 
@@ -115,6 +117,34 @@ def parse_workstreams(text: str) -> list[tuple[str, str]]:
     return rows
 
 
+def parse_priority_scope(text: str) -> str:
+    """Read the committed-outcome blockquote under the Current Priority Scope heading.
+
+    The heading is followed by review-cadence prose before the quote starts, so this
+    skips lines until the first '> ' line rather than requiring the quote immediately
+    below the heading.
+    """
+    lines = text.splitlines()
+    start = next((i for i, line in enumerate(lines) if PRIORITY_SCOPE_HEADING.match(line)), None)
+    if start is None:
+        raise RenderError("CONTRIBUTING.md: no '## Current Priority Scope' section")
+
+    quote_lines: list[str] = []
+    for line in lines[start + 1 :]:
+        if line.startswith(">"):
+            quote_lines.append(line[1:].strip())
+        elif quote_lines:
+            break  # the blockquote has ended
+        elif ANY_HEADING.match(line):
+            break  # the section ended before any blockquote appeared
+
+    if not quote_lines:
+        raise RenderError(
+            "CONTRIBUTING.md: no blockquote follows '## Current Priority Scope'"
+        )
+    return " ".join(quote_lines)
+
+
 def _to_html(markdown: str) -> str:
     """Escape everything, then rebuild links from an allowlisted scheme."""
 
@@ -134,7 +164,13 @@ def render_workstreams(rows: list[tuple[str, str]]) -> str:
     )
 
 
-def render(template: str, source: Path, governance: str, starburst: str) -> str:
+def render_priority_scope(scope: str) -> str:
+    # The blockquote sits in a text position in the template, not an attribute, but
+    # it is a build input like GOVERNANCE.md, so it is escaped for the same reason.
+    return html.escape(scope)
+
+
+def render(template: str, source: Path, governance: str, contributing: str, starburst: str) -> str:
     """Replace every placeholder. Fail if one is missing from the template or survives it.
 
     Both directions matter. A surviving token means the renderer did not know about it.
@@ -150,6 +186,9 @@ def render(template: str, source: Path, governance: str, starburst: str) -> str:
     out = out.replace("<!--ACS:SCHEMA_COUNT-->", str(count))
     out = out.replace("<!--ACS:SCHEMA_HREF-->", html.escape(f"schema/{version}/acs_schema.json"))
     out = out.replace("<!--ACS:WORKSTREAMS-->", render_workstreams(parse_workstreams(governance)))
+    out = out.replace(
+        "<!--ACS:PRIORITY_SCOPE-->", render_priority_scope(parse_priority_scope(contributing))
+    )
     # Inlining is required: an SVG loaded through <img> cannot read the page's CSS
     # custom properties, so the diagram would ignore the theme.
     out = out.replace("<!--ACS:STARBURST-->", starburst)
@@ -169,6 +208,7 @@ def main(argv: list[str]) -> int:
             (landing / "index.html").read_text(encoding="utf-8"),
             repo / "specification",
             (repo / "GOVERNANCE.md").read_text(encoding="utf-8"),
+            (repo / "CONTRIBUTING.md").read_text(encoding="utf-8"),
             (landing / "assets" / "starburst.svg").read_text(encoding="utf-8"),
         )
     except (RenderError, SchemaError) as error:


### PR DESCRIPTION
Operationalizes the contribution governance the core team agreed on September 8, filtered through the Strategic Adoption Plan v3 committed outcome.

Design: `design/2026-09-09-contribution-governance-design.md` (v1.1)
Plan: `design/plans/2026-09-09-contribution-governance.md`

## What this installs

**Current Priority Scope.** `CONTRIBUTING.md` gains one section that states what the project is driving at for the next ninety days, what is deferred to v0.2.0, and what is out of scope by design. It is stated once. Every other surface links to it rather than restating it, and the landing page now renders it straight out of `CONTRIBUTING.md` so the two cannot drift.

**Branching.** `main` publishes the site and all 44 schema `$id` URIs on merge, so specification and code land on `integration` and publish on a deliberate promotion. A guard (`tools/base_branch_guard.py`, 16 tests) enforces a positive path allowlist and fails closed on anything nobody anticipated. The promotion exemption checks the head *repository*, not just the ref, so a fork branch named `integration` cannot walk a schema change onto the publishing branch.

**Intake.** Blank issues are off. Six forms route by type, and no form can stamp a `scope:`, `priority:`, `workstream:`, or `status:accepted` label. That prohibition is the whole structural guarantee behind maintainer-only triage. The sixth form asks for nothing but a description, because the strongest outside contribution this project has received would have fit none of the other five.

**The gate.** A change to behavior, normative text, or code references an issue carrying `status:accepted`. An editorial correction does not, wherever it lands. A pull request whose issue is not accepted yet is neither closed nor reviewed. It waits, and a bot says why.

**Automation.** Four workflows: the base-branch guard, an integration sync, a weekly promotion pull request, and the intake comment. Plus a reminder that opens an issue when the priority scope passes its review date.

**Phase 2 executor.** `tools/apply_governance.py` performs the live migration steps idempotently, `--dry-run` by default. It is structurally incapable of merging, closing, or retargeting a pull request, and a test asserts no code path can emit those commands.

## Authorship policy change

The rule that a maintainer strips a `Co-Authored-By` trailer naming a model is removed. The project now mandates neither direction. The human `Signed-off-by` stays required, because only a person can make the DCO certification. A standard about agent provenance should not erase the provenance of its own commits.

## Reviewer notes

- Nothing on the published site changes except the landing page's Contribute section. I built the full pipeline from `main` and from this branch and diffed: the only files that differ are `index.html` and `acs.css`. All 44 schemas are byte identical.
- 253 tests pass. `mkdocs build --strict` passes.
- This targets `integration` rather than `main` because it touches `.github/`, `tools/`, and `tests/`, which is exactly what the guard it installs requires.

## Still to do after this merges

Retarget #63, #24, #60, and #22 to `integration`. Merge #21, #20, and #22 when the team is ready. Then run the executor for rulesets, default branch, required check, and the seeded issues. The order that matters is in the plan.
