### PR TITLE
Close the governance gaps the reference implementation opened

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -44,6 +44,13 @@
 /docs/stylesheets/ @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @bar-capsule
 /docs/assets/      @rocklambros @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp @afogel @bar-capsule
 
+# The reference implementation is runnable code that contributors install and wire
+# into their own development environments, which is a different risk class from the
+# rest of this repository. It arrived as roughly 41,000 lines from a single author, so
+# these entries exist to force a second reviewer on every later change rather than to
+# record who wrote it.
+/reference-implementations/  @rocklambros @afogel @bar-capsule @fewdisc @GangGreenTemperTatum @mamicidal @sclintonowasp
+
 # CI runs with write access to the repository. Changes here are a
 # privilege-escalation surface, so this list stays narrower than the default
 # and who sits on it is a project-lead decision under GOVERNANCE.md.

--- a/.github/workflows/reference-implementation.yml
+++ b/.github/workflows/reference-implementation.yml
@@ -1,0 +1,65 @@
+# Runs the reference implementation's own tests and type check.
+#
+# The tree under reference-implementations/agt/ arrived with roughly 2,900 lines of
+# tests, a pinned-upstream verifier, and a conformance harness, and none of it ran in
+# this repository. The `test` job in deploy-pages.yml runs pytest, which collects only
+# `tests/` per `testpaths` in pyproject.toml, so a TypeScript regression here would have
+# reached main with every check green.
+#
+# No workflow expression appears inside a `run:` block. The two that appear in the
+# concurrency group are an integer pull request number and a ref name GitHub validates,
+# and a concurrency group is not a shell context.
+#
+# Scoped by path. A documentation or schema change should not pay for a Bun install.
+name: Reference implementation
+
+on:
+  pull_request:
+    paths:
+      - "reference-implementations/**"
+      - ".github/workflows/reference-implementation.yml"
+  push:
+    branches: ["main", "integration"]
+    paths:
+      - "reference-implementations/**"
+      - ".github/workflows/reference-implementation.yml"
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: reference-implementation-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  agt:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: reference-implementations/agt
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # Pinned to an exact version rather than a moving major. The bridge in
+      # packages/agt-bridge/src/opa-path.ts works around a Bun defect measured on a
+      # specific version, so the runtime version is part of this tree's contract
+      # rather than an implementation detail.
+      - name: Install Bun
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.1
+        with:
+          bun-version: "1.3.11"
+
+      - name: Install dependencies from the lockfile
+        run: bun install --frozen-lockfile
+
+      - name: Type check
+        run: bun run typecheck
+
+      # Every envelope validates against ../../../../../specification/v0.1.0/ by
+      # relative path, so this also proves the implementation still matches the
+      # schemas in this repository rather than a copy of them.
+      - name: Run the tests
+        run: bun test

--- a/.github/workflows/reference-implementation.yml
+++ b/.github/workflows/reference-implementation.yml
@@ -55,6 +55,15 @@ jobs:
       - name: Install dependencies from the lockfile
         run: bun install --frozen-lockfile
 
+      # The test helpers delete fixture directories with `trash` rather than `rm -rf`,
+      # a deliberate safety choice by the author. `trash` is not an npm dependency of
+      # this tree and `bun install` never provides it, so 26 tests fail on any machine
+      # without it, including a clean runner. Pinned to an exact version because an
+      # unpinned global install is a supply-chain surface. The undeclared dependency
+      # itself is tracked as an issue rather than papered over here.
+      - name: Install the trash CLI the test helpers shell out to
+        run: bun add --global trash-cli@7.2.0
+
       - name: Type check
         run: bun run typecheck
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,8 +27,16 @@ Partial reports are welcome. We would rather triage something incomplete than ne
 | Hook or event definitions that leak sensitive data by design | Missing security headers on sites we do not operate |
 | Supply-chain issues in this repository's dependencies | Social engineering of maintainers or contributors |
 | The published site at genai-security-project.github.io/agent-control-standard, including the landing page, the documentation, and the schema endpoints | Missing security response headers on the Pages site, which GitHub Pages does not allow us to set |
+| The reference implementation under `reference-implementations/`, which is runnable code people install and wire into a live development environment | Gaps the reference implementation documents about itself, which are tracked as issues rather than handled as reports |
 
 A specification flaw counts. If a hook definition forces implementers to log secrets, or an event schema makes an authorization bypass easy to write, that is a finding even though no code here executes.
+
+Code here does now execute. The reference implementation under `reference-implementations/`
+runs a Guardian process and installs hooks into a coding agent, so a report against it is
+in scope on the same terms as everything else above. Read that tree's own README first. It
+states plainly which ACS-Core requirements it does not yet meet, including request signing
+and replay protection, and a report that restates a documented gap is better filed as an
+issue where the discussion is public.
 
 ## Response commitments
 


### PR DESCRIPTION
Closes the governance gaps that #60 opened, found by a six-perspective adversarial review run against that tree before it merged.

**A CI workflow that runs the tree's own tests.** #60 arrived with roughly 2,900 lines of tests, a pinned-upstream verifier and a conformance harness, and none of it ran here. The `test` job in `deploy-pages.yml` runs pytest, which collects only `tests/` per `testpaths`, so a TypeScript regression would have reached `main` with every check green. Path-scoped so a documentation change does not pay for a Bun install. Bun is pinned to an exact version rather than a major, because `packages/agt-bridge/src/opa-path.ts` works around a Bun defect measured on a specific version, which makes the runtime version part of the tree's contract.

**A CODEOWNERS entry.** `reference-implementations/` had no owner at all, so nothing forced a second reviewer on it. The tree is roughly 41,000 lines from a single author, and `GOVERNANCE.md` sets two leads per workstream precisely so decisions keep moving when one person is unavailable. That redundancy did not exist here.

**A SECURITY.md scope row.** The policy opens with "ACS is a specification... the security surface is narrower than a typical software project" and the scope table listed specification flaws, schema errors and build tooling. The repository now ships a Guardian people run and hooks they wire into a live development environment. The first report against that tree would have landed on a process never scoped to accept it. The new text also points a reporter at the tree's own README, which states which ACS-Core requirements it does not meet, so a documented gap becomes a public issue rather than a private report.

`NOTICE` needed nothing. #60 added the Microsoft AGT paragraph itself, and `policy/LICENSE-AGT` reproduces the MIT text correctly.

## What the review found that this does not fix

Recorded so it is not mistaken for handled. The wire is unauthenticated and the ACS-Core HMAC signature is not implemented, which the tree's own README states. The default failure posture is `proceed`, which is issues #32 and #37 and is scheduled for a Day 30 decision. Raw envelopes reach `.acs/envelopes.jsonl` before any redaction runs, with no file mode set. `ACS_OPA_PATH` substitutes the policy evaluator with no integrity check. Each of these is getting its own issue.

- 204 tests pass, `mkdocs build --strict` clean
