### PR TITLE
Record Richard Bird as sole Identity lead

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -10,13 +10,19 @@ ACS is an OWASP project. This file records who leads the work, which workstream 
 
 ## Workstream leads
 
-Each workstream owns a slice of the standard and runs its own review. Two leads per workstream keeps decisions moving when one is unavailable.
+Each workstream owns a slice of the standard and runs its own review. Two leads per
+workstream keeps decisions moving when one is unavailable.
+
+Identity currently runs with one lead. That second seat is open, and it is open in the
+same sense as the Reference Implementation, Documentation, and Testing and Validation
+seats: the work continues, and a single point of failure sits on it until somebody
+takes it.
 
 | Workstream | Leads |
 | --- | --- |
 | Coding Agents | Almog Langleben ([@almogbhl](https://github.com/almogbhl)), Stefano Amorelli ([@stefanoamorelli](https://github.com/stefanoamorelli)) |
 | Development (SDK) | Rock Lambros ([@rocklambros](https://github.com/rocklambros)), Fred Wilmot ([@fewdisc](https://github.com/fewdisc)) |
-| Identity | Eva Benn ([@evabenn](https://github.com/evabenn)), Richard Bird ([@RbBuiltWrong](https://github.com/RbBuiltWrong)) |
+| Identity | Richard Bird ([@RbBuiltWrong](https://github.com/RbBuiltWrong)) |
 | Outreach | Eva Benn ([@evabenn](https://github.com/evabenn)), Aruneesh Salhotra ([@aruneeshsalhotra](https://github.com/aruneeshsalhotra)) |
 | Spec | Bar Kaduri ([@bar-capsule](https://github.com/bar-capsule)), Ariel Fogel ([@afogel](https://github.com/afogel)) |
 


### PR DESCRIPTION
Eva Benn is no longer a co-lead of the Identity workstream. She remains a co-lead of Outreach, so she keeps her CODEOWNERS entries and her line in CONTRIBUTORS.md, and `project.owasp.yaml` never named her because its schema caps leaders at five and carries the project lead plus the two creators.

`GOVERNANCE.md` states that two leads per workstream keeps decisions moving when one is unavailable. That sentence stops describing Identity the moment this lands, so rather than leave it quietly false, the second seat is recorded as open alongside the Reference Implementation, Documentation, and Testing and Validation seats.

`GOVERNANCE.md` is a build input. `tools/render_landing.py` parses the workstream table into the published landing page, so this changes the site. Verified by building the full pipeline: the table renders Identity as Richard Bird alone and Outreach unchanged with Eva and Aruneesh, and the single-lead row parses without incident.

204 tests pass, `mkdocs build --strict` clean.