### PR TITLE
Update Reference Implementation README.md to identify current version as a POC

### DIFF
--- a/reference-implementations/agt/README.md
+++ b/reference-implementations/agt/README.md
@@ -2,6 +2,8 @@
 
 This tree shows what Microsoft's [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit) (AGT) looks like when it talks to agent clients over the [Agent Control Standard](../../README.md) (ACS) wire contract.
 
+### NOTE: This current work represents a Proof of Concept, not a production system
+
 AGT's policy engine runs unchanged. Two different agent clients send it ACS envelopes. One Guardian process answers both. No client has AGT code in it, and AGT has no client code in it.
 
 The tree validates every envelope against the schemas in this repository's own [`specification/v0.1.0/`](../../specification/v0.1.0/), so the implementation and the specification cannot drift apart. The code reaches those schemas by a relative path, so the tree has to stay at this depth, `reference-implementations/agt`.


### PR DESCRIPTION
## What changed

Update README to communicate reference implementation maturity

## Type of change

- [ ] Specification change (schema, hooks, events, AgBOM)
- [X] Documentation
- [ ] Tooling or CI
- [ ] Governance (licensing, security policy, contributor docs)


## Checklist

- [X] Commits are signed off with `git commit -s` (required by the DCO)
- [X] Prose follows [STYLE.md](../STYLE.md)
- [X] `uv run mkdocs build --strict` passes
- [X] No secrets, tokens, or internal URLs in the diff

## Security

- [X] This change has no security impact
