### PR TITLE
Sync integration from main

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -10,13 +10,19 @@ ACS is an OWASP project. This file records who leads the work, which workstream 
 
 ## Workstream leads
 
-Each workstream owns a slice of the standard and runs its own review. Two leads per workstream keeps decisions moving when one is unavailable.
+Each workstream owns a slice of the standard and runs its own review. Two leads per
+workstream keeps decisions moving when one is unavailable.
+
+Identity currently runs with one lead. That second seat is open, and it is open in the
+same sense as the Reference Implementation, Documentation, and Testing and Validation
+seats: the work continues, and a single point of failure sits on it until somebody
+takes it.
 
 | Workstream | Leads |
 | --- | --- |
 | Coding Agents | Almog Langleben ([@almogbhl](https://github.com/almogbhl)), Stefano Amorelli ([@stefanoamorelli](https://github.com/stefanoamorelli)) |
 | Development (SDK) | Rock Lambros ([@rocklambros](https://github.com/rocklambros)), Fred Wilmot ([@fewdisc](https://github.com/fewdisc)) |
-| Identity | Eva Benn ([@evabenn](https://github.com/evabenn)), Richard Bird ([@RbBuiltWrong](https://github.com/RbBuiltWrong)) |
+| Identity | Richard Bird ([@RbBuiltWrong](https://github.com/RbBuiltWrong)) |
 | Outreach | Eva Benn ([@evabenn](https://github.com/evabenn)), Aruneesh Salhotra ([@aruneeshsalhotra](https://github.com/aruneeshsalhotra)) |
 | Spec | Bar Kaduri ([@bar-capsule](https://github.com/bar-capsule)), Ariel Fogel ([@afogel](https://github.com/afogel)) |
 

--- a/reference-implementations/agt/README.md
+++ b/reference-implementations/agt/README.md
@@ -2,6 +2,8 @@
 
 This tree shows what Microsoft's [Agent Governance Toolkit](https://github.com/microsoft/agent-governance-toolkit) (AGT) looks like when it talks to agent clients over the [Agent Control Standard](../../README.md) (ACS) wire contract.
 
+### NOTE: This current work represents a Proof of Concept, not a production system
+
 AGT's policy engine runs unchanged. Two different agent clients send it ACS envelopes. One Guardian process answers both. No client has AGT code in it, and AGT has no client code in it.
 
 The tree validates every envelope against the schemas in this repository's own [`specification/v0.1.0/`](../../specification/v0.1.0/), so the implementation and the specification cannot drift apart. The code reaches those schemas by a relative path, so the tree has to stay at this depth, `reference-implementations/agt`.


### PR DESCRIPTION
integration is three commits behind main: the Identity lead change (#75), the earlier promotion merge (#76), and the Reference Implementation POC label (#79). Six open pull requests are based on integration and are therefore building on a stale tree, which turns every one of them into a conflict at promotion time rather than at merge time.

This is the merge that was actually pending. A promotion in the other direction is currently a no-op, since integration carries no commit main lacks.