### PR TITLE
Correct the one documentation claim that outlived its facts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ the conformance evidence that makes either credible:
 
 - The mandatory floor decision in PR #21, which gates everything behind it
 - The Claude Code, Cursor, and NVIDIA NAT adapters in PR #22
-- The AGT reference implementation in PR #60
+- The AGT reference implementation in `reference-implementations/agt/`
 - Ports of that reference implementation to other runtimes: Python, Go, Rust, Codex
 - Production-hardening it, including span batching and OpenTelemetry collection
 - Resolving the fail-open default, which issues #32 and #37 attack from opposite ends


### PR DESCRIPTION
A full audit of the documentation against the live repository, verifying every claim with `gh` rather than reading prose. One statement was false.

`CONTRIBUTING.md:29` described the AGT reference implementation as being "in PR #60". That pull request merged, and the code sits at `reference-implementations/agt/`. Corrected to name the path.

Everything else was checked and left alone because it was already true. That includes the default-branch statements in README and CONTRIBUTING, which became correct when the default moved to `integration`, and the `help wanted` pointer, which became correct when issues #86 through #94 were filed. Pull requests #21 and #22 and issues #18, #19, #32, #33, #37, #53 and #70 were each verified still open before their sentences were left standing.

Two semicolons flagged by the style check sit inside the Developer Certificate of Origin, which is verbatim legal text, and were deliberately not touched.

This targets `main` directly because `CONTRIBUTING.md` is on the documentation-lane allowlist. The base-branch guard should pass, which is the lane working as designed.

259 tests pass, `mkdocs build --strict` clean, landing page renders with no surviving placeholder.